### PR TITLE
rm: if vm in pod is still present, wait it stop before remove resource

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -380,12 +380,16 @@ func (daemon *Daemon) RemoveVm(vmId string) {
 }
 
 func (daemon *Daemon) DestroyAllVm() error {
+	var remains = []*Pod{}
 	daemon.PodList.Foreach(func(p *Pod) error {
+		remains = append(remains, p)
+		return nil
+	})
+	for _, p := range remains {
 		if _, _, err := daemon.StopPodWithinLock(p, "yes"); err != nil {
 			glog.V(1).Infof("fail to stop %s: %v", p.id, err)
 		}
-		return nil
-	})
+	}
 	return nil
 }
 

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -59,20 +59,24 @@ func (daemon *Daemon) List(item, podId, vmId string, auxiliary bool) (map[string
 	if item == "pod" {
 		if podId == "" && vmId == "" {
 			daemon.PodList.Foreach(func(p *Pod) error {
-				podJsonResponse = append(podJsonResponse, p.id+":"+showPod(p.status))
+				if p.status.Status != types.S_POD_NONE {
+					podJsonResponse = append(podJsonResponse, p.id+":"+showPod(p.status))
+				}
 				return nil
 			})
 		} else if podId != "" && vmId == "" {
-			podJsonResponse = append(podJsonResponse, pod.id+":"+showPod(pod.status))
+			if pod.status.Status != types.S_POD_NONE {
+				podJsonResponse = append(podJsonResponse, pod.id+":"+showPod(pod.status))
+			}
 		} else if podId == "" && vmId != "" {
 			daemon.PodList.Foreach(func(p *Pod) error {
-				if p.status.Vm == vmId {
+				if p.status.Vm == vmId && p.status.Status != types.S_POD_NONE {
 					podJsonResponse = append(podJsonResponse, p.id+":"+showPod(p.status))
 				}
 				return nil
 			})
 		} else {
-			if pod.status.Vm == vmId {
+			if pod.status.Vm == vmId && pod.status.Status != types.S_POD_NONE {
 				podJsonResponse = append(podJsonResponse, pod.id+":"+showPod(pod.status))
 			}
 		}

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -103,6 +103,8 @@ func (p *Pod) SetVM(id string, vm *hypervisor.Vm) {
 }
 
 func (p *Pod) KillVM(daemon *Daemon) {
+	p.Lock()
+	defer p.Unlock()
 	if p.vm != nil {
 		daemon.KillVm(p.vm.Id)
 		p.vm = nil

--- a/daemon/rm.go
+++ b/daemon/rm.go
@@ -36,19 +36,28 @@ func (daemon *Daemon) CleanPod(podId string) (int, string, error) {
 		}
 	}
 
-	os.RemoveAll(path.Join(utils.HYPER_ROOT, "services", podId))
-	pod.cleanupEtcHosts()
-	os.RemoveAll(path.Join(utils.HYPER_ROOT, "hosts", podId))
-
-	daemon.db.DeletePod(podId)
-	daemon.RemovePod(podId)
-	if pod.status.Type != "kubernetes" {
-		daemon.RemovePodContainer(pod)
+	pod.Lock()
+	defer pod.Unlock()
+	if pod.vm != nil {
+		pod.status.Status = types.S_POD_NONE
+		return code, cause, err
 	}
-	daemon.DeleteVolumeId(podId)
-	code = types.E_OK
 
-	return code, cause, nil
+	return daemon.RemovePodResource(pod)
+}
+
+func (daemon *Daemon) RemovePodResource(p *Pod) (int, string, error) {
+	os.RemoveAll(path.Join(utils.HYPER_ROOT, "services", p.id))
+	os.RemoveAll(path.Join(utils.HYPER_ROOT, "hosts", p.id))
+
+	daemon.db.DeletePod(p.id)
+	daemon.RemovePod(p.id)
+	if p.status.Type != "kubernetes" {
+		daemon.RemovePodContainer(p)
+	}
+	daemon.DeleteVolumeId(p.id)
+
+	return types.E_OK, "", nil
 }
 
 func (daemon *Daemon) RemovePodContainer(p *Pod) {

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -69,16 +69,7 @@ func (daemon *Daemon) StopPodWithinLock(pod *Pod, stopVm string) (int, string, e
 		return -1, "", fmt.Errorf("Pod %s is not in running state, cannot be stopped", pod.id)
 	}
 
-	vmId := pod.vm.Id
 	vmResponse := pod.vm.StopPod(pod.status, stopVm)
-
-	// Delete the Vm info for POD
-	daemon.db.DeleteVMByPod(pod.id)
-
-	if vmResponse.Code == types.E_VM_SHUTDOWN {
-		daemon.RemoveVm(vmId)
-	}
-	pod.vm = nil
 
 	return vmResponse.Code, vmResponse.Cause, nil
 }

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -68,6 +68,12 @@ function stop_hyperd()
     read  HYPERD_PID other < <(ps --ppid ${HYPERD_PID}|grep hyperd)
   fi
   [[ -n "${HYPERD_PID-}" ]] && sudo kill "${HYPERD_PID}" 1>&2 2>/dev/null
+  t=1
+  while ps -p ${HYPERD_PID} >/dev/null 2>&1 ; do
+    echo "wait hyperd(${HYPERD_PID}) stop"
+    sleep 1
+    [ $((t++)) -ge 15 ] && break
+  done
   HYPERD_PID=
 }
 


### PR DESCRIPTION
- use lock protect unset pod.vm
- when delete, if vm is present, set pod status to be None
- when vm stopped, if status is None, reclaim the resource
- when list, do not display the removed pods

Signed-off-by: Xu Wang <gnawux@gmail.com>