### PR TITLE
rm: remove pod from podlist at last

### DIFF
--- a/daemon/rm.go
+++ b/daemon/rm.go
@@ -58,12 +58,12 @@ func (daemon *Daemon) RemovePodResource(p *Pod) {
 	os.RemoveAll(path.Join(utils.HYPER_ROOT, "services", p.id))
 	os.RemoveAll(path.Join(utils.HYPER_ROOT, "hosts", p.id))
 
-	daemon.db.DeletePod(p.id)
-	daemon.RemovePod(p.id)
 	if p.status.Type != "kubernetes" {
 		daemon.RemovePodContainer(p)
 	}
 	daemon.DeleteVolumeId(p.id)
+	daemon.db.DeletePod(p.id)
+	daemon.RemovePod(p.id)
 }
 
 func (daemon *Daemon) RemovePodContainer(p *Pod) {

--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -116,7 +116,7 @@ hyper::test::with_volume() {
 }
 
 hyper::test::service() {
-    hyper::test::run_pod ${HYPER_ROOT}/hack/pods/service.pod
+    hyper::test::run_attached_pod ${HYPER_ROOT}/hack/pods/service.pod
 }
 
 hyper::test::command() {

--- a/hack/pods/service.pod
+++ b/hack/pods/service.pod
@@ -3,7 +3,7 @@
                 {
                     "image": "busybox:latest",
                     "name": "service",
-                    "command": ["/bin/sh", "-c", "ps", "aux"]
+                    "command": ["/bin/sh", "-c", "ps aux"]
                 }
             ],
             "services": [


### PR DESCRIPTION
- to run pod and rm, should let it attach, otherwise, the rm will be triggered right after the pod is launch successfully.
- the command line should be `/bin/sh -c "ps aux"`, rather than `/bin/sh -c ps aux`

Signed-off-by: Xu Wang <gnawux@gmail.com>