### PR TITLE
update centos package code for the coming 0.6 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,6 @@ package/centos/rpm/SOURCES/*
 package/centos/rpm/RPMS/*
 package/centos/rpm/SRPMS/*
 package/centos/centos-rpm.pod
-package/centos/rpm/SPECS/hyper.spec
-package/centos/rpm/SPECS/hyperstart.spec
 package/fedora/rpm/BUILD/*
 package/fedora/rpm/BUILDROOT/*
 package/fedora/rpm/SOURCES/*

--- a/package/centos/.dockerignore
+++ b/package/centos/.dockerignore
@@ -1,0 +1,3 @@
+centos-rpm.pod.in
+make-rpm.sh
+rpm

--- a/package/centos/Dockerfile
+++ b/package/centos/Dockerfile
@@ -2,18 +2,15 @@ FROM centos
 MAINTAINER Xu Wang <xu@hyper.sh>
 
 # RPM Build Environment
-RUN yum install -y @development-tools centos-packager rpmdevtools
+RUN yum install -y @development-tools centos-packager rpmdevtools || echo "WARNING: work around the yum failure"
 RUN /usr/sbin/useradd makerpm; usermod -a -G mock makerpm; su makerpm -c 'rpmdev-setuptree'
 
 # Hyper dependency
-RUN yum install -y automake autoconf gcc make glibc-devel glibc-devel.i686 device-mapper-devel pcre-devel libsepol-devel libselinux-devel systemd-devel sqlite-devel libvirt-devel
+RUN yum install -y automake autoconf gcc make glibc-devel glibc-devel.i686 device-mapper-devel pcre-devel libsepol-devel libselinux-devel systemd-devel sqlite-devel libvirt-devel|| echo "WARNING: work around the yum failure"
 RUN curl -sL https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz | tar -C /usr/local -zxf -
 
-# CBFSTool
-RUN cd /dev/shm; curl -sSL https://www.coreboot.org/releases/coreboot-4.2.tar.xz | tar --xz -xvf - ; cd coreboot-4.2/util/cbfstool ; make; cp cbfstool /usr/local/bin/
-
 # Qemu Denpendency
-RUN yum install -y gcc-c++ zlib-devel libcap-devel libattr-devel librbd1-devel libtool
+RUN yum install -y gcc-c++ zlib-devel libcap-devel libattr-devel librbd1-devel libtool || echo "WARNING: work around the yum failure"
 
 ENV PATH /usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/package/centos/make-rpm.sh
+++ b/package/centos/make-rpm.sh
@@ -2,7 +2,7 @@
 
 PROJECT=$(readlink -f $(dirname $0)/../..)
 CENTOS_DIR=${PROJECT}/package/centos
-VERSION=0.5
+VERSION=0.6
 
 if [ $# -gt 0 ] ; then
     VERSION=$1
@@ -11,22 +11,14 @@ fi
 #SOURCES
 
 cd $PROJECT
-git archive --format=tar.gz master > ${CENTOS_DIR}/rpm/SOURCES/hyper-${VERSION}.tar.gz
+git archive --format=tar.gz master > ${CENTOS_DIR}/rpm/SOURCES/hyperd-${VERSION}.tar.gz
 cd $PROJECT/../runv
 git archive --format=tar.gz master > ${CENTOS_DIR}/rpm/SOURCES/runv-${VERSION}.tar.gz
 cd $PROJECT/../hyperstart
 git archive --format=tar.gz master > ${CENTOS_DIR}/rpm/SOURCES/hyperstart-${VERSION}.tar.gz
-cd ..
-[ -d qboot ] && rm -rf qboot
-git clone https://github.com/bonzini/qboot.git
-cd qboot
-git archive --format=tar.gz master > ${CENTOS_DIR}/rpm/SOURCES/qboot.tar.gz
 curl -sSL http://wiki.qemu-project.org/download/qemu-2.4.1.tar.bz2 > ${CENTOS_DIR}/rpm/SOURCES/qemu-2.4.1.tar.bz2
 
-
 sed -e "s#%PROJECT_ROOT%#${PROJECT}#g" ${CENTOS_DIR}/centos-rpm.pod.in > ${CENTOS_DIR}/centos-rpm.pod
-sed -e "s#%VERSION%#${VERSION}#g" ${CENTOS_DIR}/rpm/SPECS/hyper.spec.in > ${CENTOS_DIR}/rpm/SPECS/hyper.spec
-sed -e "s#%VERSION%#${VERSION}#g" ${CENTOS_DIR}/rpm/SPECS/hyperstart.spec.in > ${CENTOS_DIR}/rpm/SPECS/hyperstart.spec
 
 ${PROJECT}/hyper run -a --rm -p ${CENTOS_DIR}/centos-rpm.pod
 

--- a/package/centos/rpm/SPECS/hyper-container.spec
+++ b/package/centos/rpm/SPECS/hyper-container.spec
@@ -1,13 +1,13 @@
-Summary:            Hyper is a VM based docker runtime
-Name:               hyper
-Version:            %VERSION%
+Summary:            Hyper Container is a VM based docker runtime
+Name:               hyper-container
+Version:            0.6
 Release:            1%{?dist}
 License:            Apache License, Version 2.0
 Group:              System Environment/Base
 # The source for this package was pulled from upstream's git repo. Use the
 # following commands to generate the tarball:
-#  git archive --format=tar.gz master > hyper-%{version}.tar.gz
-Source0:            %{name}-%{version}.tar.gz
+#  git archive --format=tar.gz master > hyperd-%{version}.tar.gz
+Source0:            hyperd-%{version}.tar.gz
 # and the https://github.com/hyperhq/runv.git
 #  git archive --format=tar.gz master > runv-%{version}.tar.gz
 Source1:            runv-%{version}.tar.gz
@@ -24,13 +24,13 @@ Hyper is a VM based docker engine, it start a container image in
 VM without a full guest OS
 
 %prep
-mkdir -p %{_builddir}/src/github.com/hyperhq/hyper
+mkdir -p %{_builddir}/src/github.com/hyperhq/hyperd
 mkdir -p %{_builddir}/src/github.com/hyperhq/runv
-tar -C %{_builddir}/src/github.com/hyperhq/hyper -xvf %SOURCE0
+tar -C %{_builddir}/src/github.com/hyperhq/hyperd -xvf %SOURCE0
 tar -C %{_builddir}/src/github.com/hyperhq/runv -xvf %SOURCE1
 
 %build
-cd %{_builddir}/src/github.com/hyperhq/hyper
+cd %{_builddir}/src/github.com/hyperhq/hyperd
 export GOPATH=%{_builddir}
 ./autogen.sh
 ./configure
@@ -40,9 +40,9 @@ make %{?_smp_mflags}
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_sysconfdir}
 mkdir -p %{buildroot}/lib/systemd/system/
-cp %{_builddir}/src/github.com/hyperhq/hyper/{hyperctl,hyperd} %{buildroot}%{_bindir}
-cp -a %{_builddir}/src/github.com/hyperhq/hyper/package/dist/etc/hyper %{buildroot}%{_sysconfdir}
-cp -a %{_builddir}/src/github.com/hyperhq/hyper/package/dist/lib/systemd/system/hyperd.service %{buildroot}/lib/systemd/system/hyperd.service
+cp %{_builddir}/src/github.com/hyperhq/hyperd/{hyperctl,hyperd} %{buildroot}%{_bindir}
+cp -a %{_builddir}/src/github.com/hyperhq/hyperd/package/dist/etc/hyper %{buildroot}%{_sysconfdir}
+cp -a %{_builddir}/src/github.com/hyperhq/hyperd/package/dist/lib/systemd/system/hyperd.service %{buildroot}/lib/systemd/system/hyperd.service
 
 %clean
 rm -rf %{buildroot}
@@ -53,6 +53,9 @@ rm -rf %{buildroot}
 /lib/systemd/system/hyperd.service
 
 %changelog
+* Thu Apr 28 2016 Xu Wang <xu@hyper.sh> - 0.6-1
+- update source to 0.6
+- rename package
 * Sat Jan 30 2016 Xu Wang <xu@hyper.sh> - 0.5-1
 - update source to 0.5
 - introduce libvirt dependency

--- a/package/centos/rpm/SPECS/hyperstart.spec
+++ b/package/centos/rpm/SPECS/hyperstart.spec
@@ -1,6 +1,6 @@
 Summary:            Hyperstart is the initrd for hyper VM
 Name:               hyperstart
-Version:            %VERSION%
+Version:            0.6
 Release:            1%{?dist}
 License:            Apache License, Version 2.0
 Group:              System Environment/Base
@@ -8,8 +8,6 @@ Group:              System Environment/Base
 # following commands to generate the tarball:
 #  git archive --format=tar.gz master > hyperstart-%{version}.tar.gz
 Source0:            %{name}-%{version}.tar.gz
-#  git archive --format=tar.gz master > qboot.tar.gz
-Source1:            qboot.tar.gz
 URL:                https://hyper.sh/
 ExclusiveArch:      x86_64
 
@@ -21,24 +19,17 @@ image.
 %prep
 mkdir -p %{_builddir}/src/github.com/hyperhq/hyperstart
 tar -C %{_builddir}/src/github.com/hyperhq/hyperstart -xvf %SOURCE0
-mkdir -p %{_builddir}/src/qboot
-tar -C %{_builddir}/src/qboot -xvf %SOURCE1
 
 %build
 cd %{_builddir}/src/github.com/hyperhq/hyperstart
 ./autogen.sh
 ./configure
 make %{?_smp_mflags}
-make cbfs
-cd %{_builddir}/src/qboot
-make
 
 %install
 mkdir -p %{buildroot}%{_sharedstatedir}/hyper
 cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/kernel %{buildroot}%{_sharedstatedir}/hyper/
 cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/hyper-initrd.img %{buildroot}%{_sharedstatedir}/hyper/
-cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/cbfs.rom %{buildroot}%{_sharedstatedir}/hyper/cbfs-qboot.rom
-cp %{_builddir}/src/qboot/bios.bin %{buildroot}%{_sharedstatedir}/hyper/bios-qboot.bin
 
 %clean
 rm -rf %{buildroot}
@@ -47,6 +38,12 @@ rm -rf %{buildroot}
 %{_sharedstatedir}/*
 
 %changelog
+* Thu Apr 28 2016 Xu Wang <xu@hyper.sh> - 0.6-1
+- update source to 0.6
+- kernel update to 4.4.7, and will modules provided
+- volume population support
+- tty processing improvement
+- many other fix and improvement
 * Sat Jan 30 2016 Xu Wang <xu@hyper.sh> - 0.5-1
 - update source to 0.5
 * Fri Jan 29 2016 Xu Wang <xu@hyper.sh> - 0.4-2

--- a/package/centos/rpm/build.sh
+++ b/package/centos/rpm/build.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-su makerpm -c "rpmbuild -ba hyper.spec"
+su makerpm -c "rpmbuild -ba hyper-container.spec"
 su makerpm -c "rpmbuild -ba hyperstart.spec"
 su makerpm -c "rpmbuild -ba qemu-hyper.spec"
 ls -lh ../RPMS/x86_64
-sleep 60
 sync


### PR DESCRIPTION
- use spec instead spec.in
- eliminate qboot and cbfs
- rename package name and source package name
- add `.dockerignore`

Signed-off-by: Xu Wang <gnawux@gmail.com>