### PR TITLE
travis-ci: build hyperd in install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,15 @@ before_install:
   - cd lvm2-2_02_131
   - ./configure && make device-mapper && sudo make install
 
-script:
+# override the default `install`, otherwise default `install` will export ${TRAVIS_BUILD_DIR}/Godeps/_workspace as GOPATH
+# see https://docs.travis-ci.com/user/languages/go#Dependency-Management
+
+install:
   - cd ${TRAVIS_BUILD_DIR}
   - hack/install-grpc.sh
   - hack/verify-gofmt.sh
   - hack/verify-generated-proto.sh
-  - ./autogen.sh
-  - ./configure
-  - make
-  - hack/test-cmd.sh
+  - ./autogen.sh && ./configure && make
+
+script:
+  - cd ${TRAVIS_BUILD_DIR} && hack/test-cmd.sh


### PR DESCRIPTION
If commands in install return a non-zero exit code,
travis will stop immediately, this will give us explicit
error message.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>