### PR TITLE
remove 'su makerpm' when build rpm

### DIFF
--- a/package/centos/rpm/build.sh
+++ b/package/centos/rpm/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-su makerpm -c "rpmbuild -ba hyper.spec"
-su makerpm -c "rpmbuild -ba hyperstart.spec"
-su makerpm -c "rpmbuild -ba qemu-hyper.spec"
+rpmbuild -ba hyper.spec
+rpmbuild -ba hyperstart.spec
+rpmbuild -ba qemu-hyper.spec
 ls -lh ../RPMS/x86_64
 sleep 60
 sync

--- a/package/fedora/rpm/build.sh
+++ b/package/fedora/rpm/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-su makerpm -c "rpmbuild -ba hyper.spec"
-su makerpm -c "rpmbuild -ba hyperstart.spec"
+rpmbuild -ba hyper.spec
+rpmbuild -ba hyperstart.spec
 ls -lh ../RPMS/x86_64
 sync


### PR DESCRIPTION
the USER is set in the Dockerfile and the user is switched to makerpm
when build.sh is called.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>