### PR TITLE
Separate pod and container creation

### DIFF
--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -1196,7 +1196,7 @@ func (p *Pod) Start(daemon *Daemon, vmId string, lazy bool, streams []*hyperviso
 
 	for _, cInfo := range p.ctnStartInfo {
 		var cUser pod.UserContainer
-		err := p.vm.NewContainer(&cUser, cInfo)
+		_, err := p.vm.NewContainer(&cUser, cInfo)
 		if err != nil {
 			glog.Error(err.Error())
 			return nil, err

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -1202,6 +1202,8 @@ func (p *Pod) Start(daemon *Daemon, vmId string, lazy bool, streams []*hyperviso
 			return nil, err
 		}
 	}
+	// Set the container status to online
+	p.status.SetContainerStatus(types.S_POD_RUNNING)
 
 	err = daemon.db.UpdateVM(p.vm.Id, vmResponse.Data.([]byte))
 	if err != nil {

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -1231,6 +1231,11 @@ func hyperHandlePodEvent(vmResponse *types.VmResponse, data interface{},
 		mypod.SetPodContainerStatus(vmResponse.Data.([]uint32))
 		vm.Status = types.S_VM_IDLE
 		return false
+	case types.E_CONTAINER_FINISHED:
+		result := vmResponse.Data.(*hypervisor.ContainerFinished)
+		mypod.ContainerCode[result.Idx] = result.Code
+		glog.V(1).Infof("Container %d finished with %d", result.Idx, result.Code)
+		return false
 	case types.E_VM_SHUTDOWN: // vm exited, sucessful or not
 		if mypod.Status == types.S_POD_RUNNING { // not received finished pod before
 			stopLogger(mypod)


### PR DESCRIPTION
1. Separate pod and container creation
2. handle E_CONTAINER_FINISHED event

This lay the groundwork for supporting special volume mappings (git/http etc). Work with https://github.com/hyperhq/runv/pull/232 and https://github.com/hyperhq/hyperstart/pull/103

Can be tested with https://github.com/bergwolf/hyperd/commit/0db24fe74f42ce1a7d104d8b01dda4974b7338b5