### PR TITLE
add err condition avoid panic

### DIFF
--- a/client/images.go
+++ b/client/images.go
@@ -30,6 +30,9 @@ func (cli *HyperClient) HyperCmdImages(args ...string) error {
 	}
 
 	remoteInfo, err := cli.client.GetImages(opts.All, opts.Quiet)
+	if err != nil {
+		return err
+	}
 
 	var (
 		imagesList = []string{}


### PR DESCRIPTION
Get panic when I run command `hyperctl images` with non-privileged user. 
Fix it.

Signed-off-by: Crazykev <crazykev@zju.edu.cn>