### PR TITLE
do not wait cleanup job finished in hyperd

### DIFF
--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -38,7 +38,6 @@ type Pod struct {
 	ctnStartInfo []*hypervisor.ContainerInfo
 	volumes      map[string]*hypervisor.VolumeInfo
 	ttyList      map[string]*hypervisor.TtyIO
-	wg           *sync.WaitGroup
 
 	transiting chan bool
 	sync.RWMutex
@@ -242,7 +241,6 @@ func NewPod(podSpec *apitypes.UserPod, id string, data interface{}) (*Pod, error
 		ttyList:    make(map[string]*hypervisor.TtyIO),
 		volumes:    make(map[string]*hypervisor.VolumeInfo),
 		transiting: make(chan bool, 1),
-		wg:         new(sync.WaitGroup),
 	}
 
 	// fill one element in transit chan, only one parallel op is allowed
@@ -1201,7 +1199,6 @@ func (p *Pod) Start(daemon *Daemon, vmId string, lazy bool, streams []*hyperviso
 		return vmResponse, err
 	}
 
-	p.wg.Add(1)
 	err = daemon.db.UpdateVM(p.vm.Id, vmResponse.Data.([]byte))
 	if err != nil {
 		glog.Error(err.Error())


### PR DESCRIPTION
depends on https://github.com/hyperhq/runv/pull/242

after vm.StartPod, pod event handler may or may not run, it's
difficult to know if we should wait pod event handler.

Do the waiting in runv.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>