### PR TITLE
Implement rpc for SetPodLabels and PodStats

### DIFF
--- a/integration/client.go
+++ b/integration/client.go
@@ -534,6 +534,20 @@ func (c *HyperClient) ListService(podID string) ([]*types.UserService, error) {
 	return resp.Services, nil
 }
 
+// GetPodStats get stats of Pod by podID
+func (c *HyperClient) GetPodStats(podID string) (*types.PodStats, error) {
+	statsResponse, err := c.client.PodStats(
+		c.ctx,
+		&types.PodStatsRequest{PodID: podID},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return statsResponse.PodStats, nil
+}
+
 // AddService adds user service by podID and service content
 func (c *HyperClient) AddService(podID string, services []*types.UserService) error {
 	_, err := c.client.ServiceAdd(
@@ -554,10 +568,37 @@ func (c *HyperClient) UpdateService(podID string, services []*types.UserService)
 		c.ctx,
 		&types.ServiceUpdateRequest{PodID: podID, Services: services},
 	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SetPodLabels sets labels to Pod by podID
+func (c *HyperClient) SetPodLabels(podID string, override bool, labels map[string]string) error {
+	_, err := c.client.SetPodLabels(
+		c.ctx,
+		&types.PodLabelsRequest{PodID: podID, Override: override, Labels: labels},
+	)
 
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// Info gets system info of hyperd
+func (c *HyperClient) Info() (*types.InfoResponse, error) {
+	info, err := c.client.Info(
+		c.ctx,
+		&types.InfoRequest{},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }

--- a/serverrpc/pod.go
+++ b/serverrpc/pod.go
@@ -163,3 +163,15 @@ func (s *ServerRPC) PodUnpause(ctx context.Context, req *types.PodUnpauseRequest
 
 	return &types.PodUnpauseResponse{}, nil
 }
+
+func (s *ServerRPC) PodLabels(c context.Context, req *types.PodLabelsRequest) (*types.PodLabelsResponse, error) {
+	glog.V(3).Infof("Set pod labels with request %v", req.String())
+
+	err := s.daemon.SetPodLabels(req.PodID, req.override, req.labels)
+	if err != nil {
+		glog.Errorf("PodLabels error: %v", err)
+		return nil, err
+	}
+
+	return &types.PodLabelsResponse{}, nil
+}

--- a/serverrpc/pod.go
+++ b/serverrpc/pod.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/hyperhq/hyperd/types"
+	runvtypes "github.com/hyperhq/runv/hypervisor/types"
 	"golang.org/x/net/context"
 )
 
@@ -164,14 +165,181 @@ func (s *ServerRPC) PodUnpause(ctx context.Context, req *types.PodUnpauseRequest
 	return &types.PodUnpauseResponse{}, nil
 }
 
-func (s *ServerRPC) PodLabels(c context.Context, req *types.PodLabelsRequest) (*types.PodLabelsResponse, error) {
+// PodLabels sets the labels of Pod
+func (s *ServerRPC) SetPodLabels(c context.Context, req *types.PodLabelsRequest) (*types.PodLabelsResponse, error) {
 	glog.V(3).Infof("Set pod labels with request %v", req.String())
 
-	err := s.daemon.SetPodLabels(req.PodID, req.override, req.labels)
+	err := s.daemon.SetPodLabels(req.PodID, req.Override, req.Labels)
 	if err != nil {
 		glog.Errorf("PodLabels error: %v", err)
 		return nil, err
 	}
 
 	return &types.PodLabelsResponse{}, nil
+}
+
+// PodStats get stats (runvtypes.PodStats) of Pod
+func (s *ServerRPC) PodStats(c context.Context, req *types.PodStatsRequest) (*types.PodStatsResponse, error) {
+	glog.V(3).Infof("Get pod stats with request %v", req.String())
+
+	statsObject, err := s.daemon.GetPodStats(req.PodID)
+	if err != nil {
+		glog.Errorf("PodStats error: %v", err)
+		return nil, err
+	}
+
+	stats := statsObject.(*runvtypes.PodStats)
+
+	return &types.PodStatsResponse{
+		PodStats: convertRunvStatsToGrpcTypes(stats),
+	}, nil
+}
+
+func convertRunvStatsToGrpcTypes(stats *runvtypes.PodStats) *types.PodStats {
+	grpcPodStats := &types.PodStats{}
+	grpcPodStats.Cpu = convertToGrpcCpuStats(stats.Cpu)
+	grpcPodStats.Block = convertToGrpcBlockStats(stats.Block)
+	grpcPodStats.Memory = convertToGrpcMemoryStats(stats.Memory)
+	grpcPodStats.Network = convertToGrpcNetworkStats(stats.Network)
+	grpcPodStats.Timestamp = stats.Timestamp.Unix()
+
+	for _, fs := range stats.Filesystem {
+		grpcPodStats.Filesystem = append(grpcPodStats.Filesystem, convertRunvFsToGrpcType(fs))
+	}
+
+	for _, cStats := range stats.ContainersStats {
+		var containerStats *types.ContainersStats
+		containerStats.ContainerID = cStats.ContainerID
+		containerStats.Cpu = convertToGrpcCpuStats(cStats.Cpu)
+		containerStats.Memory = convertToGrpcMemoryStats(cStats.Memory)
+		containerStats.Block = convertToGrpcBlockStats(cStats.Block)
+		containerStats.Network = convertToGrpcNetworkStats(cStats.Network)
+		for _, fs := range cStats.Filesystem {
+			containerStats.Filesystem = append(containerStats.Filesystem, convertRunvFsToGrpcType(fs))
+		}
+		containerStats.Timestamp = cStats.Timestamp.Unix()
+		grpcPodStats.ContainersStats = append(grpcPodStats.ContainersStats, containerStats)
+	}
+	return grpcPodStats
+}
+
+func convertToGrpcCpuStats(stats runvtypes.CpuStats) *types.CpuStats {
+	return &types.CpuStats{
+		Usage: &types.CpuUsage{
+			Total:  stats.Usage.Total,
+			PerCpu: stats.Usage.PerCpu,
+			User:   stats.Usage.User,
+			System: stats.Usage.System,
+		},
+		LoadAverage: stats.LoadAverage,
+	}
+}
+
+func convertToGrpcMemoryStats(stats runvtypes.MemoryStats) *types.MemoryStats {
+	return &types.MemoryStats{
+		Usage:      stats.Usage,
+		WorkingSet: stats.WorkingSet,
+		Failcnt:    stats.Failcnt,
+		ContainerData: &types.MemoryStatsMemoryData{
+			Pgfault:    stats.ContainerData.Pgfault,
+			Pgmajfault: stats.ContainerData.Pgmajfault,
+		},
+		HierarchicalData: &types.MemoryStatsMemoryData{
+			Pgfault:    stats.ContainerData.Pgfault,
+			Pgmajfault: stats.ContainerData.Pgmajfault,
+		},
+	}
+}
+
+func convertToGrpcBlockStats(stats runvtypes.BlkioStats) *types.BlkioStats {
+	return &types.BlkioStats{
+		IoServiceBytesRecursive: covertToGrpcBlockEntry(stats.IoServiceBytesRecursive),
+		IoServicedRecursive:     covertToGrpcBlockEntry(stats.IoServicedRecursive),
+		IoQueuedRecursive:       covertToGrpcBlockEntry(stats.IoQueuedRecursive),
+		IoServiceTimeRecursive:  covertToGrpcBlockEntry(stats.IoServiceTimeRecursive),
+		IoWaitTimeRecursive:     covertToGrpcBlockEntry(stats.IoWaitTimeRecursive),
+		IoMergedRecursive:       covertToGrpcBlockEntry(stats.IoMergedRecursive),
+		IoTimeRecursive:         covertToGrpcBlockEntry(stats.IoTimeRecursive),
+		SectorsRecursive:        covertToGrpcBlockEntry(stats.SectorsRecursive),
+	}
+}
+
+func convertToGrpcNetworkStats(stats runvtypes.NetworkStats) *types.NetworkStats {
+	return &types.NetworkStats{
+		Interfaces: convertToGrpcInterfaceStats(stats.Interfaces),
+		Tcp:        convertToGrpcTcpStats(stats.Tcp),
+		Tcp6:       convertToGrpcTcpStats(stats.Tcp6),
+	}
+}
+
+func convertToGrpcTcpStats(stats runvtypes.TcpStat) *types.TcpStat {
+	return &types.TcpStat{
+		Established: stats.Established,
+		SynSent:     stats.SynSent,
+		SynRecv:     stats.SynRecv,
+		FinWait1:    stats.FinWait1,
+		FinWait2:    stats.FinWait2,
+		TimeWait:    stats.TimeWait,
+		Close:       stats.Close,
+		CloseWait:   stats.CloseWait,
+		LastAck:     stats.LastAck,
+		Listen:      stats.Listen,
+		Closing:     stats.Closing,
+	}
+}
+
+func convertToGrpcInterfaceStats(iStats []runvtypes.InterfaceStats) []*types.InterfaceStats {
+	var result []*types.InterfaceStats
+	for _, f := range iStats {
+		item := &types.InterfaceStats{
+			Name:      f.Name,
+			RxBytes:   f.RxBytes,
+			RxPackets: f.RxPackets,
+			RxErrors:  f.RxErrors,
+			RxDropped: f.RxDropped,
+			TxBytes:   f.TxBytes,
+			TxPackets: f.TxPackets,
+			TxErrors:  f.TxErrors,
+			TxDropped: f.TxDropped,
+		}
+		result = append(result, item)
+	}
+
+	return result
+}
+
+func covertToGrpcBlockEntry(bStats []runvtypes.BlkioStatEntry) []*types.BlkioStatEntry {
+	var result []*types.BlkioStatEntry
+	for _, b := range bStats {
+		item := &types.BlkioStatEntry{
+			Name:   b.Name,
+			Type:   b.Type,
+			Source: b.Source,
+			Major:  b.Major,
+			Minor:  b.Minor,
+			Stat:   b.Stat,
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func convertRunvFsToGrpcType(fs runvtypes.FsStats) *types.FsStats {
+	var grpcFs *types.FsStats
+	grpcFs.Device = fs.Device
+	grpcFs.Limit = fs.Limit
+	grpcFs.Usage = fs.Usage
+	grpcFs.Available = fs.Available
+	grpcFs.ReadsCompleted = fs.ReadsCompleted
+	grpcFs.ReadsMerged = fs.ReadsMerged
+	grpcFs.SectorsRead = fs.SectorsRead
+	grpcFs.ReadTime = fs.ReadTime
+	grpcFs.WritesCompleted = fs.WritesCompleted
+	grpcFs.WritesMerged = fs.WritesMerged
+	grpcFs.SectorsWritten = fs.SectorsWritten
+	grpcFs.WriteTime = fs.WriteTime
+	grpcFs.IoInProgress = fs.IoInProgress
+	grpcFs.IoTime = fs.IoTime
+	grpcFs.WeightedIoTime = fs.WeightedIoTime
+	return grpcFs
 }

--- a/types/types.pb.go
+++ b/types/types.pb.go
@@ -103,6 +103,8 @@ It has these top-level messages:
 	PodPauseResponse
 	PodUnpauseRequest
 	PodUnpauseResponse
+	PodLabelsRequest
+	PodLabelsResponse
 */
 package types
 
@@ -1456,6 +1458,30 @@ func (m *PodUnpauseResponse) Reset()         { *m = PodUnpauseResponse{} }
 func (m *PodUnpauseResponse) String() string { return proto.CompactTextString(m) }
 func (*PodUnpauseResponse) ProtoMessage()    {}
 
+type PodLabelsRequest struct {
+	PodId    string            `protobuf:"bytes,1,opt,name=podId,proto3" json:"podId,omitempty"`
+	Override bool              `protobuf:"varint,2,opt,name=override,proto3" json:"override,omitempty"`
+	Labels   map[string]string `protobuf:"bytes,3,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (m *PodLabelsRequest) Reset()         { *m = PodLabelsRequest{} }
+func (m *PodLabelsRequest) String() string { return proto.CompactTextString(m) }
+func (*PodLabelsRequest) ProtoMessage()    {}
+
+func (m *PodLabelsRequest) GetLabels() map[string]string {
+	if m != nil {
+		return m.Labels
+	}
+	return nil
+}
+
+type PodLabelsResponse struct {
+}
+
+func (m *PodLabelsResponse) Reset()         { *m = PodLabelsResponse{} }
+func (m *PodLabelsResponse) String() string { return proto.CompactTextString(m) }
+func (*PodLabelsResponse) ProtoMessage()    {}
+
 func init() {
 	proto.RegisterType((*ContainerPort)(nil), "types.ContainerPort")
 	proto.RegisterType((*EnvironmentVar)(nil), "types.EnvironmentVar")
@@ -1551,6 +1577,8 @@ func init() {
 	proto.RegisterType((*PodPauseResponse)(nil), "types.PodPauseResponse")
 	proto.RegisterType((*PodUnpauseRequest)(nil), "types.PodUnpauseRequest")
 	proto.RegisterType((*PodUnpauseResponse)(nil), "types.PodUnpauseResponse")
+	proto.RegisterType((*PodLabelsRequest)(nil), "types.PodLabelsRequest")
+	proto.RegisterType((*PodLabelsResponse)(nil), "types.PodLabelsResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1590,6 +1618,8 @@ type PublicAPIClient interface {
 	VMCreate(ctx context.Context, in *VMCreateRequest, opts ...grpc.CallOption) (*VMCreateResponse, error)
 	// VMRemove deletes a HyperVM by vmID
 	VMRemove(ctx context.Context, in *VMRemoveRequest, opts ...grpc.CallOption) (*VMRemoveResponse, error)
+	// PodLabels implements  POST   /pod/labels
+	PodLabels(ctx context.Context, in *PodLabelsRequest, opts ...grpc.CallOption) (*PodLabelsResponse, error)
 	// ContainerLogs gets the log of specified container
 	ContainerLogs(ctx context.Context, in *ContainerLogsRequest, opts ...grpc.CallOption) (PublicAPI_ContainerLogsClient, error)
 	// ContainerCreate creates a container in specified pod
@@ -1786,6 +1816,15 @@ func (c *publicAPIClient) VMCreate(ctx context.Context, in *VMCreateRequest, opt
 func (c *publicAPIClient) VMRemove(ctx context.Context, in *VMRemoveRequest, opts ...grpc.CallOption) (*VMRemoveResponse, error) {
 	out := new(VMRemoveResponse)
 	err := grpc.Invoke(ctx, "/types.PublicAPI/VMRemove", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *publicAPIClient) PodLabels(ctx context.Context, in *PodLabelsRequest, opts ...grpc.CallOption) (*PodLabelsResponse, error) {
+	out := new(PodLabelsResponse)
+	err := grpc.Invoke(ctx, "/types.PublicAPI/PodLabels", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2073,6 +2112,8 @@ type PublicAPIServer interface {
 	VMCreate(context.Context, *VMCreateRequest) (*VMCreateResponse, error)
 	// VMRemove deletes a HyperVM by vmID
 	VMRemove(context.Context, *VMRemoveRequest) (*VMRemoveResponse, error)
+	// PodLabels implements  POST   /pod/labels
+	PodLabels(context.Context, *PodLabelsRequest) (*PodLabelsResponse, error)
 	// ContainerLogs gets the log of specified container
 	ContainerLogs(*ContainerLogsRequest, PublicAPI_ContainerLogsServer) error
 	// ContainerCreate creates a container in specified pod
@@ -2302,6 +2343,18 @@ func _PublicAPI_VMRemove_Handler(srv interface{}, ctx context.Context, dec func(
 		return nil, err
 	}
 	out, err := srv.(PublicAPIServer).VMRemove(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _PublicAPI_PodLabels_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(PodLabelsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(PublicAPIServer).PodLabels(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -2602,6 +2655,10 @@ var _PublicAPI_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "VMRemove",
 			Handler:    _PublicAPI_VMRemove_Handler,
+		},
+		{
+			MethodName: "PodLabels",
+			Handler:    _PublicAPI_PodLabels_Handler,
 		},
 		{
 			MethodName: "ContainerCreate",

--- a/types/types.pb.go
+++ b/types/types.pb.go
@@ -24,6 +24,18 @@ It has these top-level messages:
 	PodStatus
 	PodInfo
 	ImageInfo
+	PodStats
+	CpuStats
+	CpuUsage
+	BlkioStats
+	BlkioStatEntry
+	MemoryStats
+	MemoryStatsMemoryData
+	NetworkStats
+	TcpStat
+	InterfaceStats
+	FsStats
+	ContainersStats
 	PodInfoRequest
 	PodInfoResponse
 	PodListRequest
@@ -105,6 +117,8 @@ It has these top-level messages:
 	PodUnpauseResponse
 	PodLabelsRequest
 	PodLabelsResponse
+	PodStatsRequest
+	PodStatsResponse
 */
 package types
 
@@ -452,6 +466,351 @@ func (*ImageInfo) ProtoMessage()    {}
 func (m *ImageInfo) GetLabels() map[string]string {
 	if m != nil {
 		return m.Labels
+	}
+	return nil
+}
+
+type PodStats struct {
+	Cpu             *CpuStats          `protobuf:"bytes,1,opt,name=cpu" json:"cpu,omitempty"`
+	Block           *BlkioStats        `protobuf:"bytes,2,opt,name=block" json:"block,omitempty"`
+	Memory          *MemoryStats       `protobuf:"bytes,3,opt,name=memory" json:"memory,omitempty"`
+	Network         *NetworkStats      `protobuf:"bytes,4,opt,name=network" json:"network,omitempty"`
+	Filesystem      []*FsStats         `protobuf:"bytes,5,rep,name=filesystem" json:"filesystem,omitempty"`
+	Timestamp       int64              `protobuf:"varint,6,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	ContainersStats []*ContainersStats `protobuf:"bytes,7,rep,name=containersStats" json:"containersStats,omitempty"`
+}
+
+func (m *PodStats) Reset()         { *m = PodStats{} }
+func (m *PodStats) String() string { return proto.CompactTextString(m) }
+func (*PodStats) ProtoMessage()    {}
+
+func (m *PodStats) GetCpu() *CpuStats {
+	if m != nil {
+		return m.Cpu
+	}
+	return nil
+}
+
+func (m *PodStats) GetBlock() *BlkioStats {
+	if m != nil {
+		return m.Block
+	}
+	return nil
+}
+
+func (m *PodStats) GetMemory() *MemoryStats {
+	if m != nil {
+		return m.Memory
+	}
+	return nil
+}
+
+func (m *PodStats) GetNetwork() *NetworkStats {
+	if m != nil {
+		return m.Network
+	}
+	return nil
+}
+
+func (m *PodStats) GetFilesystem() []*FsStats {
+	if m != nil {
+		return m.Filesystem
+	}
+	return nil
+}
+
+func (m *PodStats) GetContainersStats() []*ContainersStats {
+	if m != nil {
+		return m.ContainersStats
+	}
+	return nil
+}
+
+type CpuStats struct {
+	Usage       *CpuUsage `protobuf:"bytes,1,opt,name=usage" json:"usage,omitempty"`
+	LoadAverage int32     `protobuf:"varint,2,opt,name=LoadAverage,proto3" json:"LoadAverage,omitempty"`
+}
+
+func (m *CpuStats) Reset()         { *m = CpuStats{} }
+func (m *CpuStats) String() string { return proto.CompactTextString(m) }
+func (*CpuStats) ProtoMessage()    {}
+
+func (m *CpuStats) GetUsage() *CpuUsage {
+	if m != nil {
+		return m.Usage
+	}
+	return nil
+}
+
+type CpuUsage struct {
+	Total  uint64   `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
+	PerCpu []uint64 `protobuf:"varint,2,rep,name=perCpu" json:"perCpu,omitempty"`
+	User   uint64   `protobuf:"varint,3,opt,name=user,proto3" json:"user,omitempty"`
+	System uint64   `protobuf:"varint,4,opt,name=system,proto3" json:"system,omitempty"`
+}
+
+func (m *CpuUsage) Reset()         { *m = CpuUsage{} }
+func (m *CpuUsage) String() string { return proto.CompactTextString(m) }
+func (*CpuUsage) ProtoMessage()    {}
+
+type BlkioStats struct {
+	IoServiceBytesRecursive []*BlkioStatEntry `protobuf:"bytes,1,rep,name=ioServiceBytesRecursive" json:"ioServiceBytesRecursive,omitempty"`
+	IoServicedRecursive     []*BlkioStatEntry `protobuf:"bytes,2,rep,name=ioServicedRecursive" json:"ioServicedRecursive,omitempty"`
+	IoQueuedRecursive       []*BlkioStatEntry `protobuf:"bytes,3,rep,name=ioQueuedRecursive" json:"ioQueuedRecursive,omitempty"`
+	IoServiceTimeRecursive  []*BlkioStatEntry `protobuf:"bytes,4,rep,name=ioServiceTimeRecursive" json:"ioServiceTimeRecursive,omitempty"`
+	IoWaitTimeRecursive     []*BlkioStatEntry `protobuf:"bytes,5,rep,name=ioWaitTimeRecursive" json:"ioWaitTimeRecursive,omitempty"`
+	IoMergedRecursive       []*BlkioStatEntry `protobuf:"bytes,6,rep,name=ioMergedRecursive" json:"ioMergedRecursive,omitempty"`
+	IoTimeRecursive         []*BlkioStatEntry `protobuf:"bytes,7,rep,name=ioTimeRecursive" json:"ioTimeRecursive,omitempty"`
+	SectorsRecursive        []*BlkioStatEntry `protobuf:"bytes,8,rep,name=sectorsRecursive" json:"sectorsRecursive,omitempty"`
+}
+
+func (m *BlkioStats) Reset()         { *m = BlkioStats{} }
+func (m *BlkioStats) String() string { return proto.CompactTextString(m) }
+func (*BlkioStats) ProtoMessage()    {}
+
+func (m *BlkioStats) GetIoServiceBytesRecursive() []*BlkioStatEntry {
+	if m != nil {
+		return m.IoServiceBytesRecursive
+	}
+	return nil
+}
+
+func (m *BlkioStats) GetIoServicedRecursive() []*BlkioStatEntry {
+	if m != nil {
+		return m.IoServicedRecursive
+	}
+	return nil
+}
+
+func (m *BlkioStats) GetIoQueuedRecursive() []*BlkioStatEntry {
+	if m != nil {
+		return m.IoQueuedRecursive
+	}
+	return nil
+}
+
+func (m *BlkioStats) GetIoServiceTimeRecursive() []*BlkioStatEntry {
+	if m != nil {
+		return m.IoServiceTimeRecursive
+	}
+	return nil
+}
+
+func (m *BlkioStats) GetIoWaitTimeRecursive() []*BlkioStatEntry {
+	if m != nil {
+		return m.IoWaitTimeRecursive
+	}
+	return nil
+}
+
+func (m *BlkioStats) GetIoMergedRecursive() []*BlkioStatEntry {
+	if m != nil {
+		return m.IoMergedRecursive
+	}
+	return nil
+}
+
+func (m *BlkioStats) GetIoTimeRecursive() []*BlkioStatEntry {
+	if m != nil {
+		return m.IoTimeRecursive
+	}
+	return nil
+}
+
+func (m *BlkioStats) GetSectorsRecursive() []*BlkioStatEntry {
+	if m != nil {
+		return m.SectorsRecursive
+	}
+	return nil
+}
+
+type BlkioStatEntry struct {
+	Name   string            `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Type   string            `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Source string            `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
+	Major  uint64            `protobuf:"varint,4,opt,name=major,proto3" json:"major,omitempty"`
+	Minor  uint64            `protobuf:"varint,5,opt,name=minor,proto3" json:"minor,omitempty"`
+	Stat   map[string]uint64 `protobuf:"bytes,6,rep,name=stat" json:"stat,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
+}
+
+func (m *BlkioStatEntry) Reset()         { *m = BlkioStatEntry{} }
+func (m *BlkioStatEntry) String() string { return proto.CompactTextString(m) }
+func (*BlkioStatEntry) ProtoMessage()    {}
+
+func (m *BlkioStatEntry) GetStat() map[string]uint64 {
+	if m != nil {
+		return m.Stat
+	}
+	return nil
+}
+
+type MemoryStats struct {
+	Usage            uint64                 `protobuf:"varint,1,opt,name=usage,proto3" json:"usage,omitempty"`
+	WorkingSet       uint64                 `protobuf:"varint,2,opt,name=workingSet,proto3" json:"workingSet,omitempty"`
+	Failcnt          uint64                 `protobuf:"varint,3,opt,name=failcnt,proto3" json:"failcnt,omitempty"`
+	ContainerData    *MemoryStatsMemoryData `protobuf:"bytes,4,opt,name=containerData" json:"containerData,omitempty"`
+	HierarchicalData *MemoryStatsMemoryData `protobuf:"bytes,5,opt,name=hierarchicalData" json:"hierarchicalData,omitempty"`
+}
+
+func (m *MemoryStats) Reset()         { *m = MemoryStats{} }
+func (m *MemoryStats) String() string { return proto.CompactTextString(m) }
+func (*MemoryStats) ProtoMessage()    {}
+
+func (m *MemoryStats) GetContainerData() *MemoryStatsMemoryData {
+	if m != nil {
+		return m.ContainerData
+	}
+	return nil
+}
+
+func (m *MemoryStats) GetHierarchicalData() *MemoryStatsMemoryData {
+	if m != nil {
+		return m.HierarchicalData
+	}
+	return nil
+}
+
+type MemoryStatsMemoryData struct {
+	Pgfault    uint64 `protobuf:"varint,1,opt,name=pgfault,proto3" json:"pgfault,omitempty"`
+	Pgmajfault uint64 `protobuf:"varint,2,opt,name=pgmajfault,proto3" json:"pgmajfault,omitempty"`
+}
+
+func (m *MemoryStatsMemoryData) Reset()         { *m = MemoryStatsMemoryData{} }
+func (m *MemoryStatsMemoryData) String() string { return proto.CompactTextString(m) }
+func (*MemoryStatsMemoryData) ProtoMessage()    {}
+
+type NetworkStats struct {
+	Interfaces []*InterfaceStats `protobuf:"bytes,1,rep,name=interfaces" json:"interfaces,omitempty"`
+	Tcp        *TcpStat          `protobuf:"bytes,2,opt,name=tcp" json:"tcp,omitempty"`
+	Tcp6       *TcpStat          `protobuf:"bytes,3,opt,name=tcp6" json:"tcp6,omitempty"`
+}
+
+func (m *NetworkStats) Reset()         { *m = NetworkStats{} }
+func (m *NetworkStats) String() string { return proto.CompactTextString(m) }
+func (*NetworkStats) ProtoMessage()    {}
+
+func (m *NetworkStats) GetInterfaces() []*InterfaceStats {
+	if m != nil {
+		return m.Interfaces
+	}
+	return nil
+}
+
+func (m *NetworkStats) GetTcp() *TcpStat {
+	if m != nil {
+		return m.Tcp
+	}
+	return nil
+}
+
+func (m *NetworkStats) GetTcp6() *TcpStat {
+	if m != nil {
+		return m.Tcp6
+	}
+	return nil
+}
+
+type TcpStat struct {
+	Established uint64 `protobuf:"varint,1,opt,name=established,proto3" json:"established,omitempty"`
+	SynSent     uint64 `protobuf:"varint,2,opt,name=synSent,proto3" json:"synSent,omitempty"`
+	SynRecv     uint64 `protobuf:"varint,3,opt,name=synRecv,proto3" json:"synRecv,omitempty"`
+	FinWait1    uint64 `protobuf:"varint,4,opt,name=finWait1,proto3" json:"finWait1,omitempty"`
+	FinWait2    uint64 `protobuf:"varint,5,opt,name=finWait2,proto3" json:"finWait2,omitempty"`
+	TimeWait    uint64 `protobuf:"varint,6,opt,name=timeWait,proto3" json:"timeWait,omitempty"`
+	Close       uint64 `protobuf:"varint,7,opt,name=close,proto3" json:"close,omitempty"`
+	CloseWait   uint64 `protobuf:"varint,8,opt,name=closeWait,proto3" json:"closeWait,omitempty"`
+	LastAck     uint64 `protobuf:"varint,9,opt,name=lastAck,proto3" json:"lastAck,omitempty"`
+	Listen      uint64 `protobuf:"varint,10,opt,name=listen,proto3" json:"listen,omitempty"`
+	Closing     uint64 `protobuf:"varint,11,opt,name=closing,proto3" json:"closing,omitempty"`
+}
+
+func (m *TcpStat) Reset()         { *m = TcpStat{} }
+func (m *TcpStat) String() string { return proto.CompactTextString(m) }
+func (*TcpStat) ProtoMessage()    {}
+
+type InterfaceStats struct {
+	Name      string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	RxBytes   uint64 `protobuf:"varint,2,opt,name=rxBytes,proto3" json:"rxBytes,omitempty"`
+	RxPackets uint64 `protobuf:"varint,3,opt,name=rxPackets,proto3" json:"rxPackets,omitempty"`
+	RxErrors  uint64 `protobuf:"varint,4,opt,name=rxErrors,proto3" json:"rxErrors,omitempty"`
+	RxDropped uint64 `protobuf:"varint,5,opt,name=rxDropped,proto3" json:"rxDropped,omitempty"`
+	TxBytes   uint64 `protobuf:"varint,6,opt,name=txBytes,proto3" json:"txBytes,omitempty"`
+	TxPackets uint64 `protobuf:"varint,7,opt,name=txPackets,proto3" json:"txPackets,omitempty"`
+	TxErrors  uint64 `protobuf:"varint,8,opt,name=txErrors,proto3" json:"txErrors,omitempty"`
+	TxDropped uint64 `protobuf:"varint,9,opt,name=txDropped,proto3" json:"txDropped,omitempty"`
+}
+
+func (m *InterfaceStats) Reset()         { *m = InterfaceStats{} }
+func (m *InterfaceStats) String() string { return proto.CompactTextString(m) }
+func (*InterfaceStats) ProtoMessage()    {}
+
+type FsStats struct {
+	Device          string `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
+	Limit           uint64 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
+	Usage           uint64 `protobuf:"varint,3,opt,name=usage,proto3" json:"usage,omitempty"`
+	Available       uint64 `protobuf:"varint,4,opt,name=available,proto3" json:"available,omitempty"`
+	ReadsCompleted  uint64 `protobuf:"varint,5,opt,name=readsCompleted,proto3" json:"readsCompleted,omitempty"`
+	ReadsMerged     uint64 `protobuf:"varint,6,opt,name=readsMerged,proto3" json:"readsMerged,omitempty"`
+	SectorsRead     uint64 `protobuf:"varint,7,opt,name=sectorsRead,proto3" json:"sectorsRead,omitempty"`
+	ReadTime        uint64 `protobuf:"varint,8,opt,name=readTime,proto3" json:"readTime,omitempty"`
+	WritesCompleted uint64 `protobuf:"varint,9,opt,name=writesCompleted,proto3" json:"writesCompleted,omitempty"`
+	WritesMerged    uint64 `protobuf:"varint,10,opt,name=writesMerged,proto3" json:"writesMerged,omitempty"`
+	SectorsWritten  uint64 `protobuf:"varint,11,opt,name=sectorsWritten,proto3" json:"sectorsWritten,omitempty"`
+	WriteTime       uint64 `protobuf:"varint,12,opt,name=writeTime,proto3" json:"writeTime,omitempty"`
+	IoInProgress    uint64 `protobuf:"varint,13,opt,name=ioInProgress,proto3" json:"ioInProgress,omitempty"`
+	IoTime          uint64 `protobuf:"varint,14,opt,name=ioTime,proto3" json:"ioTime,omitempty"`
+	WeightedIoTime  uint64 `protobuf:"varint,15,opt,name=weightedIoTime,proto3" json:"weightedIoTime,omitempty"`
+}
+
+func (m *FsStats) Reset()         { *m = FsStats{} }
+func (m *FsStats) String() string { return proto.CompactTextString(m) }
+func (*FsStats) ProtoMessage()    {}
+
+type ContainersStats struct {
+	ContainerID string        `protobuf:"bytes,1,opt,name=containerID,proto3" json:"containerID,omitempty"`
+	Cpu         *CpuStats     `protobuf:"bytes,2,opt,name=cpu" json:"cpu,omitempty"`
+	Block       *BlkioStats   `protobuf:"bytes,3,opt,name=block" json:"block,omitempty"`
+	Memory      *MemoryStats  `protobuf:"bytes,4,opt,name=memory" json:"memory,omitempty"`
+	Network     *NetworkStats `protobuf:"bytes,5,opt,name=network" json:"network,omitempty"`
+	Filesystem  []*FsStats    `protobuf:"bytes,6,rep,name=filesystem" json:"filesystem,omitempty"`
+	Timestamp   int64         `protobuf:"varint,7,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+}
+
+func (m *ContainersStats) Reset()         { *m = ContainersStats{} }
+func (m *ContainersStats) String() string { return proto.CompactTextString(m) }
+func (*ContainersStats) ProtoMessage()    {}
+
+func (m *ContainersStats) GetCpu() *CpuStats {
+	if m != nil {
+		return m.Cpu
+	}
+	return nil
+}
+
+func (m *ContainersStats) GetBlock() *BlkioStats {
+	if m != nil {
+		return m.Block
+	}
+	return nil
+}
+
+func (m *ContainersStats) GetMemory() *MemoryStats {
+	if m != nil {
+		return m.Memory
+	}
+	return nil
+}
+
+func (m *ContainersStats) GetNetwork() *NetworkStats {
+	if m != nil {
+		return m.Network
+	}
+	return nil
+}
+
+func (m *ContainersStats) GetFilesystem() []*FsStats {
+	if m != nil {
+		return m.Filesystem
 	}
 	return nil
 }
@@ -1459,7 +1818,7 @@ func (m *PodUnpauseResponse) String() string { return proto.CompactTextString(m)
 func (*PodUnpauseResponse) ProtoMessage()    {}
 
 type PodLabelsRequest struct {
-	PodId    string            `protobuf:"bytes,1,opt,name=podId,proto3" json:"podId,omitempty"`
+	PodID    string            `protobuf:"bytes,1,opt,name=podID,proto3" json:"podID,omitempty"`
 	Override bool              `protobuf:"varint,2,opt,name=override,proto3" json:"override,omitempty"`
 	Labels   map[string]string `protobuf:"bytes,3,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
@@ -1482,6 +1841,29 @@ func (m *PodLabelsResponse) Reset()         { *m = PodLabelsResponse{} }
 func (m *PodLabelsResponse) String() string { return proto.CompactTextString(m) }
 func (*PodLabelsResponse) ProtoMessage()    {}
 
+type PodStatsRequest struct {
+	PodID string `protobuf:"bytes,1,opt,name=podID,proto3" json:"podID,omitempty"`
+}
+
+func (m *PodStatsRequest) Reset()         { *m = PodStatsRequest{} }
+func (m *PodStatsRequest) String() string { return proto.CompactTextString(m) }
+func (*PodStatsRequest) ProtoMessage()    {}
+
+type PodStatsResponse struct {
+	PodStats *PodStats `protobuf:"bytes,1,opt,name=podStats" json:"podStats,omitempty"`
+}
+
+func (m *PodStatsResponse) Reset()         { *m = PodStatsResponse{} }
+func (m *PodStatsResponse) String() string { return proto.CompactTextString(m) }
+func (*PodStatsResponse) ProtoMessage()    {}
+
+func (m *PodStatsResponse) GetPodStats() *PodStats {
+	if m != nil {
+		return m.PodStats
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*ContainerPort)(nil), "types.ContainerPort")
 	proto.RegisterType((*EnvironmentVar)(nil), "types.EnvironmentVar")
@@ -1498,6 +1880,18 @@ func init() {
 	proto.RegisterType((*PodStatus)(nil), "types.PodStatus")
 	proto.RegisterType((*PodInfo)(nil), "types.PodInfo")
 	proto.RegisterType((*ImageInfo)(nil), "types.ImageInfo")
+	proto.RegisterType((*PodStats)(nil), "types.PodStats")
+	proto.RegisterType((*CpuStats)(nil), "types.CpuStats")
+	proto.RegisterType((*CpuUsage)(nil), "types.CpuUsage")
+	proto.RegisterType((*BlkioStats)(nil), "types.BlkioStats")
+	proto.RegisterType((*BlkioStatEntry)(nil), "types.BlkioStatEntry")
+	proto.RegisterType((*MemoryStats)(nil), "types.MemoryStats")
+	proto.RegisterType((*MemoryStatsMemoryData)(nil), "types.MemoryStatsMemoryData")
+	proto.RegisterType((*NetworkStats)(nil), "types.NetworkStats")
+	proto.RegisterType((*TcpStat)(nil), "types.TcpStat")
+	proto.RegisterType((*InterfaceStats)(nil), "types.InterfaceStats")
+	proto.RegisterType((*FsStats)(nil), "types.FsStats")
+	proto.RegisterType((*ContainersStats)(nil), "types.ContainersStats")
 	proto.RegisterType((*PodInfoRequest)(nil), "types.PodInfoRequest")
 	proto.RegisterType((*PodInfoResponse)(nil), "types.PodInfoResponse")
 	proto.RegisterType((*PodListRequest)(nil), "types.PodListRequest")
@@ -1579,6 +1973,8 @@ func init() {
 	proto.RegisterType((*PodUnpauseResponse)(nil), "types.PodUnpauseResponse")
 	proto.RegisterType((*PodLabelsRequest)(nil), "types.PodLabelsRequest")
 	proto.RegisterType((*PodLabelsResponse)(nil), "types.PodLabelsResponse")
+	proto.RegisterType((*PodStatsRequest)(nil), "types.PodStatsRequest")
+	proto.RegisterType((*PodStatsResponse)(nil), "types.PodStatsResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1618,8 +2014,10 @@ type PublicAPIClient interface {
 	VMCreate(ctx context.Context, in *VMCreateRequest, opts ...grpc.CallOption) (*VMCreateResponse, error)
 	// VMRemove deletes a HyperVM by vmID
 	VMRemove(ctx context.Context, in *VMRemoveRequest, opts ...grpc.CallOption) (*VMRemoveResponse, error)
-	// PodLabels implements  POST   /pod/labels
-	PodLabels(ctx context.Context, in *PodLabelsRequest, opts ...grpc.CallOption) (*PodLabelsResponse, error)
+	// SetPodLabels sets labels of given pod
+	SetPodLabels(ctx context.Context, in *PodLabelsRequest, opts ...grpc.CallOption) (*PodLabelsResponse, error)
+	// PodStats gets pod stats of a given pod
+	PodStats(ctx context.Context, in *PodStatsRequest, opts ...grpc.CallOption) (*PodStatsResponse, error)
 	// ContainerLogs gets the log of specified container
 	ContainerLogs(ctx context.Context, in *ContainerLogsRequest, opts ...grpc.CallOption) (PublicAPI_ContainerLogsClient, error)
 	// ContainerCreate creates a container in specified pod
@@ -1822,9 +2220,18 @@ func (c *publicAPIClient) VMRemove(ctx context.Context, in *VMRemoveRequest, opt
 	return out, nil
 }
 
-func (c *publicAPIClient) PodLabels(ctx context.Context, in *PodLabelsRequest, opts ...grpc.CallOption) (*PodLabelsResponse, error) {
+func (c *publicAPIClient) SetPodLabels(ctx context.Context, in *PodLabelsRequest, opts ...grpc.CallOption) (*PodLabelsResponse, error) {
 	out := new(PodLabelsResponse)
-	err := grpc.Invoke(ctx, "/types.PublicAPI/PodLabels", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/types.PublicAPI/SetPodLabels", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *publicAPIClient) PodStats(ctx context.Context, in *PodStatsRequest, opts ...grpc.CallOption) (*PodStatsResponse, error) {
+	out := new(PodStatsResponse)
+	err := grpc.Invoke(ctx, "/types.PublicAPI/PodStats", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2112,8 +2519,10 @@ type PublicAPIServer interface {
 	VMCreate(context.Context, *VMCreateRequest) (*VMCreateResponse, error)
 	// VMRemove deletes a HyperVM by vmID
 	VMRemove(context.Context, *VMRemoveRequest) (*VMRemoveResponse, error)
-	// PodLabels implements  POST   /pod/labels
-	PodLabels(context.Context, *PodLabelsRequest) (*PodLabelsResponse, error)
+	// SetPodLabels sets labels of given pod
+	SetPodLabels(context.Context, *PodLabelsRequest) (*PodLabelsResponse, error)
+	// PodStats gets pod stats of a given pod
+	PodStats(context.Context, *PodStatsRequest) (*PodStatsResponse, error)
 	// ContainerLogs gets the log of specified container
 	ContainerLogs(*ContainerLogsRequest, PublicAPI_ContainerLogsServer) error
 	// ContainerCreate creates a container in specified pod
@@ -2349,12 +2758,24 @@ func _PublicAPI_VMRemove_Handler(srv interface{}, ctx context.Context, dec func(
 	return out, nil
 }
 
-func _PublicAPI_PodLabels_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _PublicAPI_SetPodLabels_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
 	in := new(PodLabelsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(PublicAPIServer).PodLabels(ctx, in)
+	out, err := srv.(PublicAPIServer).SetPodLabels(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _PublicAPI_PodStats_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(PodStatsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(PublicAPIServer).PodStats(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -2657,8 +3078,12 @@ var _PublicAPI_serviceDesc = grpc.ServiceDesc{
 			Handler:    _PublicAPI_VMRemove_Handler,
 		},
 		{
-			MethodName: "PodLabels",
-			Handler:    _PublicAPI_PodLabels_Handler,
+			MethodName: "SetPodLabels",
+			Handler:    _PublicAPI_SetPodLabels_Handler,
+		},
+		{
+			MethodName: "PodStats",
+			Handler:    _PublicAPI_PodStats_Handler,
 		},
 		{
 			MethodName: "ContainerCreate",

--- a/types/types.proto
+++ b/types/types.proto
@@ -572,6 +572,15 @@ message PodUnpauseRequest {
 
 message PodUnpauseResponse {}
 
+message PodLabelsRequest{
+  string podId               = 1;
+  bool override              = 2;
+  map<string, string> labels = 3;
+}
+
+message PodLabelsResponse{
+}
+
 // PublicAPI defines the public APIs which are handled over TCP sockets.
 service PublicAPI {
     // PodList gets a list of pods
@@ -609,6 +618,12 @@ service PublicAPI {
     rpc VMCreate(VMCreateRequest) returns (VMCreateResponse) {}
     // VMRemove deletes a HyperVM by vmID
     rpc VMRemove(VMRemoveRequest) returns (VMRemoveResponse) {}
+
+    // PodLabels implements  POST   /pod/labels
+    rpc PodLabels(PodLabelsRequest) returns (PodLabelsResponse) {}
+
+    // TODO: implements  GET    /pod/stats
+    // GetPodStats returns `interface{}` instead of `hyperhq/runv/hypervisor/types/stats.go`, needs refactoring
 
     // ContainerLogs gets the log of specified container
     rpc ContainerLogs(ContainerLogsRequest) returns (stream ContainerLogsResponse) {}

--- a/types/types.proto
+++ b/types/types.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 
 package types;
 
-
 // Types definitions for HyperContainer
 message ContainerPort {
     string name         = 1;
@@ -136,6 +135,126 @@ message ImageInfo {
     int64 created               = 5;
     int64 virtualSize           = 6;
     map<string,string> labels   = 7;
+}
+
+message PodStats {
+  CpuStats     cpu     = 1;
+  BlkioStats   block   = 2;
+  MemoryStats  memory  = 3;
+  NetworkStats network = 4;
+
+  repeated FsStats  filesystem  = 5;
+  int64             timestamp   = 6;
+
+  repeated ContainersStats containersStats = 7;
+}
+
+message CpuStats {
+  CpuUsage usage    = 1;
+  int32 LoadAverage = 2;
+}
+
+message CpuUsage {
+  uint64          total  = 1;
+  repeated uint64 perCpu = 2;
+  uint64          user   = 3;
+  uint64          system = 4;
+}
+
+message BlkioStats {
+  repeated BlkioStatEntry ioServiceBytesRecursive = 1;
+  repeated BlkioStatEntry ioServicedRecursive     = 2;
+  repeated BlkioStatEntry ioQueuedRecursive       = 3;
+  repeated BlkioStatEntry ioServiceTimeRecursive  = 4;
+  repeated BlkioStatEntry ioWaitTimeRecursive     = 5;
+  repeated BlkioStatEntry ioMergedRecursive       = 6;
+  repeated BlkioStatEntry ioTimeRecursive         = 7;
+  repeated BlkioStatEntry sectorsRecursive        = 8;
+}
+
+message BlkioStatEntry {
+  string name       = 1;
+  string type       = 2;
+  string source     = 3;
+  uint64 major      = 4;
+  uint64 minor      = 5;
+
+  map<string, uint64> stat = 6;
+}
+
+message MemoryStats {
+  uint64 usage      = 1;
+  uint64 workingSet = 2;
+  uint64 failcnt    = 3;
+
+  MemoryStatsMemoryData containerData     = 4;
+  MemoryStatsMemoryData hierarchicalData  = 5;
+}
+
+message MemoryStatsMemoryData {
+  uint64 pgfault    = 1;
+  uint64 pgmajfault = 2;
+}
+
+message NetworkStats {
+  repeated InterfaceStats interfaces = 1;
+  TcpStat tcp                 = 2;
+  TcpStat tcp6                = 3;
+}
+
+message TcpStat {
+  uint64 established = 1;
+  uint64 synSent     = 2;
+  uint64 synRecv     = 3;
+  uint64 finWait1    = 4;
+  uint64 finWait2    = 5;
+  uint64 timeWait    = 6;
+  uint64 close       = 7;
+  uint64 closeWait   = 8;
+  uint64 lastAck     = 9;
+  uint64 listen      = 10;
+  uint64 closing     = 11;
+}
+
+message InterfaceStats {
+  string name       = 1;
+  uint64 rxBytes    = 2;
+  uint64 rxPackets  = 3;
+  uint64 rxErrors   = 4;
+  uint64 rxDropped  = 5;
+  uint64 txBytes    = 6;
+  uint64 txPackets  = 7;
+  uint64 txErrors   = 8;
+  uint64 txDropped  = 9;
+}
+
+message FsStats {
+  string device          = 1;
+  uint64 limit           = 2;
+  uint64 usage           = 3;
+  uint64 available       = 4;
+  uint64 readsCompleted  = 5;
+  uint64 readsMerged     = 6;
+  uint64 sectorsRead     = 7;
+  uint64 readTime        = 8;
+  uint64 writesCompleted = 9;
+  uint64 writesMerged    = 10;
+  uint64 sectorsWritten  = 11;
+  uint64 writeTime       = 12;
+  uint64 ioInProgress    = 13;
+  uint64 ioTime          = 14;
+  uint64 weightedIoTime  = 15;
+}
+
+message ContainersStats {
+  string       containerID = 1;
+  CpuStats     cpu         = 2;
+  BlkioStats   block       = 3;
+  MemoryStats  memory      = 4;
+  NetworkStats network     = 5;
+
+  repeated FsStats    filesystem  = 6;
+  int64 timestamp                 = 7;
 }
 
 ////////////////////   PublicAPI Request/Response   ///////////////////////////
@@ -573,12 +692,19 @@ message PodUnpauseRequest {
 message PodUnpauseResponse {}
 
 message PodLabelsRequest{
-  string podId               = 1;
+  string podID               = 1;
   bool override              = 2;
   map<string, string> labels = 3;
 }
 
-message PodLabelsResponse{
+message PodLabelsResponse{}
+
+message PodStatsRequest {
+  string podID = 1;
+}
+
+message PodStatsResponse {
+  PodStats podStats = 1;
 }
 
 // PublicAPI defines the public APIs which are handled over TCP sockets.
@@ -601,8 +727,6 @@ service PublicAPI {
     rpc PodPause(PodPauseRequest) returns (PodPauseResponse) {}
     // PodUnpause unpauses a pod
     rpc PodUnpause(PodUnpauseRequest) returns (PodUnpauseResponse) {}
-    // TODO: PodStats gets the statistics of a pod
-    // TODO: PodLabels updates labels of the specified pod
 
     // ContainerList gets a list of containers
     rpc ContainerList(ContainerListRequest) returns (ContainerListResponse) {}
@@ -619,11 +743,11 @@ service PublicAPI {
     // VMRemove deletes a HyperVM by vmID
     rpc VMRemove(VMRemoveRequest) returns (VMRemoveResponse) {}
 
-    // PodLabels implements  POST   /pod/labels
-    rpc PodLabels(PodLabelsRequest) returns (PodLabelsResponse) {}
+    // SetPodLabels sets labels of given pod
+    rpc SetPodLabels(PodLabelsRequest) returns (PodLabelsResponse) {}
 
-    // TODO: implements  GET    /pod/stats
-    // GetPodStats returns `interface{}` instead of `hyperhq/runv/hypervisor/types/stats.go`, needs refactoring
+    // PodStats gets pod stats of a given pod
+    rpc PodStats(PodStatsRequest) returns (PodStatsResponse) {}
 
     // ContainerLogs gets the log of specified container
     rpc ContainerLogs(ContainerLogsRequest) returns (stream ContainerLogsResponse) {}


### PR DESCRIPTION
gRpc implementation for:

1. SetPodLabels
2. PodStats

Use `io.Pipe` to replace `buffer` in ImagePull, since there's data race and caused nil pointer in buffer Truncate