### PR TITLE
remove tty tag from hyperd

### DIFF
--- a/client/api/attach.go
+++ b/client/api/attach.go
@@ -6,13 +6,11 @@ import (
 	"net/url"
 )
 
-func (cli *Client) Attach(container, termTag string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error {
+func (cli *Client) Attach(container string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error {
 	v := url.Values{}
-	v.Set("type", "container")
-	v.Set("value", container)
-	v.Set("tag", termTag)
+	v.Set("container", container)
 
-	err := cli.hijackRequest("attach", termTag, &v, tty, stdin, stdout, stderr)
+	err := cli.hijackRequest("attach", &v, tty, stdin, stdout, stderr)
 	if err != nil {
 		fmt.Printf("attach failed: %s\n", err.Error())
 		return err

--- a/client/api/hijack.go
+++ b/client/api/hijack.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hyperhq/hyperd/utils"
 )
 
-func (cli *Client) hijackRequest(method, tag string, v *url.Values, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error {
+func (cli *Client) hijackRequest(method string, v *url.Values, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error {
 	var (
 		hijacked = make(chan io.Closer)
 		errCh    chan error

--- a/client/api/interface.go
+++ b/client/api/interface.go
@@ -12,7 +12,7 @@ import (
 type APIInterface interface {
 	Login(auth dockertypes.AuthConfig, response *dockertypes.AuthResponse) (remove bool, err error)
 
-	Attach(container, termTag string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error
+	Attach(container string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error
 	CreateExec(containerId string, command []byte, tty bool) (string, error)
 	StartExec(containerId, execId string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error
 
@@ -28,7 +28,7 @@ type APIInterface interface {
 
 	GetPodInfo(podName string) (*types.PodInfo, error)
 	CreatePod(spec interface{}) (string, int, error)
-	StartPod(podId, vmId, tag string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) (string, error)
+	StartPod(podId, vmId string, attach, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) (string, error)
 	StopPod(podId, stopVm string) (int, string, error)
 	RmPod(id string) error
 	PausePod(podId string) error

--- a/client/api/interface.go
+++ b/client/api/interface.go
@@ -13,7 +13,9 @@ type APIInterface interface {
 	Login(auth dockertypes.AuthConfig, response *dockertypes.AuthResponse) (remove bool, err error)
 
 	Attach(container, termTag string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error
-	Exec(container, tag string, command []byte, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error
+	CreateExec(containerId string, command []byte, tty bool) (string, error)
+	StartExec(containerId, execId string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error
+
 	WinResize(id, tag string, height, width int) error
 
 	List(item, pod, vm string, aux bool) (*engine.Env, error)

--- a/client/api/misc.go
+++ b/client/api/misc.go
@@ -20,10 +20,10 @@ func (e StatusError) Error() string {
 	return fmt.Sprintf("Status: %s, Code: %d", e.Status, e.StatusCode)
 }
 
-func (cli *Client) GetExitCode(container, tag string) error {
+func (cli *Client) GetExitCode(containerId, execId string) error {
 	v := url.Values{}
-	v.Set("container", container)
-	v.Set("tag", tag)
+	v.Set("container", containerId)
+	v.Set("exec", execId)
 	code := -1
 
 	stream, _, err := cli.call("GET", "/exitcode?"+v.Encode(), nil, nil)

--- a/client/api/misc.go
+++ b/client/api/misc.go
@@ -62,12 +62,12 @@ func (cli *Client) AuthHeader(orig map[string][]string, auth types.AuthConfig) (
 	return orig, nil
 }
 
-func (cli *Client) WinResize(id, tag string, height, width int) error {
+func (cli *Client) WinResize(containerId, execId string, height, width int) error {
 	v := url.Values{}
 	v.Set("h", strconv.Itoa(height))
 	v.Set("w", strconv.Itoa(width))
-	v.Set("id", id)
-	v.Set("tag", tag)
+	v.Set("container", containerId)
+	v.Set("exec", execId)
 
 	_, _, err := readBody(cli.call("POST", "/tty/resize?"+v.Encode(), nil, nil))
 

--- a/client/api/start.go
+++ b/client/api/start.go
@@ -9,21 +9,17 @@ import (
 	"github.com/hyperhq/runv/hypervisor/types"
 )
 
-func (cli *Client) StartPod(podId, vmId, tag string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) (string, error) {
-	var attach = false
+func (cli *Client) StartPod(podId, vmId string, attach, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) (string, error) {
 	v := url.Values{}
 	v.Set("podId", podId)
 	v.Set("vmId", vmId)
 
-	if tag != "" {
-		attach = true
-		v.Set("tag", tag)
-	}
-
 	if !attach {
 		return cli.startPodWithoutTty(&v)
 	} else {
-		err := cli.hijackRequest("pod/start", tag, &v, tty, stdin, stdout, stderr)
+		v.Set("attach", "yes")
+
+		err := cli.hijackRequest("pod/start", &v, tty, stdin, stdout, stderr)
 		if err != nil {
 			fmt.Printf("StartPod failed: %s\n", err.Error())
 			return "", err

--- a/client/api/start.go
+++ b/client/api/start.go
@@ -34,7 +34,7 @@ func (cli *Client) StartPod(podId, vmId, tag string, tty bool, stdin io.ReadClos
 			return "", err
 		}
 
-		return "", cli.GetExitCode(containerId, tag)
+		return "", cli.GetExitCode(containerId, "")
 	}
 }
 

--- a/client/attach.go
+++ b/client/attach.go
@@ -26,7 +26,6 @@ func (cli *HyperClient) HyperCmdAttach(args ...string) error {
 	var (
 		podId       = args[0]
 		containerId = args[0]
-		tag         = cli.GetTag()
 		tty         bool
 	)
 
@@ -56,18 +55,17 @@ func (cli *HyperClient) HyperCmdAttach(args ...string) error {
 	}
 
 	if tty {
-
 		oldState, err := term.SetRawTerminal(cli.inFd)
 		if err != nil {
 			return err
 		}
 		defer term.RestoreTerminal(cli.inFd, oldState)
-		cli.monitorTtySize(podId, tag)
+		cli.monitorTtySize(containerId, "")
 	}
 
-	if err := cli.client.Attach(containerId, tag, tty, cli.in, cli.out, cli.err); err != nil {
+	if err := cli.client.Attach(containerId, tty, cli.in, cli.out, cli.err); err != nil {
 		return err
 	}
 
-	return cli.client.GetExitCode(containerId, tag)
+	return cli.client.GetExitCode(containerId, "")
 }

--- a/client/exec.go
+++ b/client/exec.go
@@ -56,7 +56,7 @@ func (cli *HyperClient) HyperCmdExec(args ...string) error {
 	}
 
 	if opts.Tty {
-		if err := cli.monitorTtySize(podName, execId); err != nil {
+		if err := cli.monitorTtySize(containerId, execId); err != nil {
 			fmt.Printf("Monitor tty size fail for %s!\n", podName)
 		}
 		oldState, err := term.SetRawTerminal(cli.inFd)

--- a/client/exec.go
+++ b/client/exec.go
@@ -26,14 +26,13 @@ func (cli *HyperClient) HyperCmdExec(args ...string) error {
 		}
 	}
 	if len(args) == 0 {
-		return fmt.Errorf("Can not accept the 'exec' command without POD/Container ID!")
+		return fmt.Errorf("Can not accept the 'exec' command without Container ID!")
 	}
 	if len(args) == 1 {
 		return fmt.Errorf("Can not accept the 'exec' command without command!")
 	}
 	var (
 		podName     = args[0]
-		tag         = cli.GetTag()
 		containerId string
 	)
 
@@ -51,8 +50,13 @@ func (cli *HyperClient) HyperCmdExec(args ...string) error {
 		return err
 	}
 
+	execId, err := cli.client.CreateExec(containerId, command, opts.Tty)
+	if err != nil {
+		return err
+	}
+
 	if opts.Tty {
-		if err := cli.monitorTtySize(podName, tag); err != nil {
+		if err := cli.monitorTtySize(podName, execId); err != nil {
 			fmt.Printf("Monitor tty size fail for %s!\n", podName)
 		}
 		oldState, err := term.SetRawTerminal(cli.inFd)
@@ -62,10 +66,10 @@ func (cli *HyperClient) HyperCmdExec(args ...string) error {
 		defer term.RestoreTerminal(cli.inFd, oldState)
 	}
 
-	err = cli.client.Exec(containerId, tag, command, opts.Tty, cli.in, cli.out, cli.err)
+	err = cli.client.StartExec(containerId, execId, opts.Tty, cli.in, cli.out, cli.err)
 	if err != nil {
 		return err
 	}
 
-	return cli.client.GetExitCode(containerId, tag)
+	return cli.client.GetExitCode(containerId, execId)
 }

--- a/client/run.go
+++ b/client/run.go
@@ -84,7 +84,6 @@ func (cli *HyperClient) HyperCmdRun(args ...string) (err error) {
 		spec  pod.UserPod
 		code  int
 		async = true
-		tag   string
 		tty   = false
 	)
 	json.Unmarshal([]byte(podJson), &spec)
@@ -127,7 +126,6 @@ func (cli *HyperClient) HyperCmdRun(args ...string) (err error) {
 	}
 
 	if attach {
-		tag = cli.GetTag()
 		if opts.PodFile == "" && opts.K8s == "" {
 			tty = opts.Tty
 		} else {
@@ -137,7 +135,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) (err error) {
 		if tty {
 			p, err := cli.client.GetPodInfo(podId)
 			if err == nil {
-				cli.monitorTtySize(p.Spec.Containers[0].ContainerID, tag)
+				cli.monitorTtySize(p.Spec.Containers[0].ContainerID, "")
 			}
 
 			oldState, err := term.SetRawTerminal(cli.inFd)
@@ -149,7 +147,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) (err error) {
 
 	}
 
-	_, err = cli.client.StartPod(podId, vmId, tag, tty, cli.in, cli.out, cli.err)
+	_, err = cli.client.StartPod(podId, vmId, attach, tty, cli.in, cli.out, cli.err)
 	if err != nil {
 		return
 	}

--- a/client/start.go
+++ b/client/start.go
@@ -33,7 +33,7 @@ func (cli *HyperClient) HyperCmdStart(args ...string) error {
 		vmId = args[1]
 	}
 
-	_, err = cli.client.StartPod(podId, vmId, "", false, nil, nil, nil)
+	_, err = cli.client.StartPod(podId, vmId, false, false, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/client/utils.go
+++ b/client/utils.go
@@ -57,22 +57,22 @@ func (cli *HyperClient) readStreamOutput(body io.ReadCloser, contentType string,
 	return nil
 }
 
-func (cli *HyperClient) resizeTty(id, tag string) {
+func (cli *HyperClient) resizeTty(containerId, execId string) {
 	height, width := cli.getTtySize()
 	if height == 0 && width == 0 {
 		return
 	}
-	cli.client.WinResize(id, tag, height, width)
+	cli.client.WinResize(containerId, execId, height, width)
 }
 
-func (cli *HyperClient) monitorTtySize(id, tag string) error {
+func (cli *HyperClient) monitorTtySize(containerId, execId string) error {
 	//cli.resizeTty(id, tag)
 
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, syscall.SIGWINCH)
 	go func() {
 		for range sigchan {
-			cli.resizeTty(id, tag)
+			cli.resizeTty(containerId, execId)
 		}
 	}()
 	return nil

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -9,36 +9,24 @@ import (
 	"github.com/hyperhq/runv/hypervisor/types"
 )
 
-func (daemon *Daemon) Attach(stdin io.ReadCloser, stdout io.WriteCloser, key, id, tag string) error {
+func (daemon *Daemon) Attach(stdin io.ReadCloser, stdout io.WriteCloser, container string) error {
 	var (
-		podId     string
-		vmId      string
-		container string
-		err       error
+		vmId string
+		err  error
 	)
 
 	tty := &hypervisor.TtyIO{
-		ClientTag: tag,
-		Stdin:     stdin,
-		Stdout:    stdout,
-		Callback:  make(chan *types.VmResponse, 1),
+		Stdin:    stdin,
+		Stdout:   stdout,
+		Callback: make(chan *types.VmResponse, 1),
 	}
 
-	// We need find the vm id which running POD, and stop it
-	if key == "pod" {
-		podId = id
-		container = ""
-	} else {
-		container = id
-		pod, _, err := daemon.GetPodByContainerIdOrName(container)
-		if err != nil {
-			return err
-		}
-
-		podId = pod.Id
+	pod, _, err := daemon.GetPodByContainerIdOrName(container)
+	if err != nil {
+		return err
 	}
 
-	vmId, err = daemon.GetVmByPodId(podId)
+	vmId, err = daemon.GetVmByPodId(pod.Id)
 	if err != nil {
 		return err
 	}

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -36,17 +36,6 @@ func (daemon *Daemon) Attach(stdin io.ReadCloser, stdout io.WriteCloser, key, id
 		}
 
 		podId = pod.Id
-		pod.Lock()
-		pod.ttyList[tag] = tty
-		pod.Unlock()
-
-		defer func() {
-			if err != nil && pod != nil {
-				pod.Lock()
-				delete(pod.ttyList, tag)
-				pod.Unlock()
-			}
-		}()
 	}
 
 	vmId, err = daemon.GetVmByPodId(podId)

--- a/daemon/daemonbuilder/pod.go
+++ b/daemon/daemonbuilder/pod.go
@@ -27,15 +27,14 @@ import (
 
 // ContainerAttach attaches streams to the container cID. If stream is true, it streams the output.
 func (d Docker) ContainerAttach(cId string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool) error {
-	tag := pod.RandStr(8, "alphanum")
 	<-d.hyper.Ready
 
-	err := d.Daemon.Attach(stdin, ioutils.NopWriteCloser(stdout), "container", cId, tag)
+	err := d.Daemon.Attach(stdin, ioutils.NopWriteCloser(stdout), cId)
 	if err != nil {
 		return err
 	}
 
-	code, err := d.Daemon.ExitCode(cId, tag)
+	code, err := d.Daemon.ExitCode(cId, "")
 	if err != nil {
 		return err
 	}

--- a/daemon/daemonbuilder/pod.go
+++ b/daemon/daemonbuilder/pod.go
@@ -212,7 +212,7 @@ func (d Docker) ContainerStart(cId string, hostConfig *containertypes.HostConfig
 		return
 	}
 
-	if _, _, err = d.Daemon.StartPod(nil, nil, podId, vm.Id, ""); err != nil {
+	if _, _, err = d.Daemon.StartPod(nil, nil, podId, vm.Id, false); err != nil {
 		return
 	}
 

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -18,61 +18,70 @@ func (daemon *Daemon) ExitCode(containerId, execId string) (int, error) {
 		return -1, err
 	}
 
+	status := pod.Status()
+	if status == nil {
+		return -1, fmt.Errorf("cannot find status of pod %s", pod.Id)
+	}
+
 	if execId != "" {
-		if es := pod.Status().GetExec(execId); es != nil {
+		if es := status.GetExec(execId); es != nil {
 			return int(es.ExitCode), nil
 		}
 		return -1, fmt.Errorf("cannot find exec %s", execId)
 	}
 
-	if cs := pod.Status().GetContainer(containerId); cs != nil {
+	if cs := status.GetContainer(containerId); cs != nil {
 		return int(cs.ExitCode), nil
 	}
 
 	return -1, fmt.Errorf("cannot find container %s", containerId)
 }
 
-func (daemon *Daemon) Exec(stdin io.ReadCloser, stdout io.WriteCloser, key, id, cmd, tag string, terminal bool) error {
-	var (
-		vmId      string
-		container string
-		err       error
-	)
+func (daemon *Daemon) CreateExec(containerId, cmd string, terminal bool) (string, error) {
+	execId := fmt.Sprintf("exec-%s", utils.RandStr(10, "alpha"))
 
+	glog.V(1).Infof("Get container id is %s", containerId)
+	pod, _, err := daemon.GetPodByContainerIdOrName(containerId)
+	if err != nil {
+		return "", err
+	}
+
+	status := pod.Status()
+	if status == nil || status.Status != types.S_POD_RUNNING {
+		return "", fmt.Errorf("container %s is not running", containerId)
+	}
+
+	status.AddExec(containerId, execId, cmd, terminal)
+	return execId, nil
+}
+
+func (daemon *Daemon) StartExec(stdin io.ReadCloser, stdout io.WriteCloser, containerId, execId string) error {
 	tty := &hypervisor.TtyIO{
-		ClientTag: tag,
+		ClientTag: execId,
 		Stdin:     stdin,
 		Stdout:    stdout,
 		Callback:  make(chan *types.VmResponse, 1),
 	}
 
-	execId := fmt.Sprintf("exec-%s", utils.RandStr(10, "alpha"))
+	glog.V(1).Infof("Get container id is %s", containerId)
+	pod, _, err := daemon.GetPodByContainerIdOrName(containerId)
+	if err != nil {
+		return err
+	}
 
-	// We need find the vm id which running POD, and stop it
-	if key == "pod" {
-		vmId = id
-		container = ""
-	} else {
-		glog.V(1).Infof("Get container id is %s", id)
-		pod, _, err := daemon.GetPodByContainerIdOrName(id)
-		if err != nil {
-			return err
-		}
+	status := pod.Status()
+	if status == nil || status.Status != types.S_POD_RUNNING {
+		return fmt.Errorf("container %s is not running", containerId)
+	}
 
-		container = id
+	es := status.GetExec(execId)
+	if es == nil {
+		return fmt.Errorf("Can not find exec %s", execId)
+	}
 
-		vmId, err = daemon.GetVmByPodId(pod.Id)
-		if err != nil {
-			return err
-		}
-
-		pod.Status().AddExec(container, execId, cmd)
-
-		defer func() {
-			if err != nil {
-				pod.Status().DeleteExec(execId)
-			}
-		}()
+	vmId, err := daemon.GetVmByPodId(pod.Id)
+	if err != nil {
+		return err
 	}
 
 	vm, ok := daemon.VmList.Get(vmId)
@@ -81,7 +90,7 @@ func (daemon *Daemon) Exec(stdin io.ReadCloser, stdout io.WriteCloser, key, id, 
 		return err
 	}
 
-	if err := vm.Exec(container, execId, cmd, terminal, tty); err != nil {
+	if err := vm.Exec(es.Container, es.Id, es.Cmds, es.Terminal, tty); err != nil {
 		return err
 	}
 

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -57,10 +57,9 @@ func (daemon *Daemon) CreateExec(containerId, cmd string, terminal bool) (string
 
 func (daemon *Daemon) StartExec(stdin io.ReadCloser, stdout io.WriteCloser, containerId, execId string) error {
 	tty := &hypervisor.TtyIO{
-		ClientTag: execId,
-		Stdin:     stdin,
-		Stdout:    stdout,
-		Callback:  make(chan *types.VmResponse, 1),
+		Stdin:    stdin,
+		Stdout:   stdout,
+		Callback: make(chan *types.VmResponse, 1),
 	}
 
 	glog.V(1).Infof("Get container id is %s", containerId)

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -197,7 +197,7 @@ func (daemon *Daemon) GetContainerInfo(name string) (types.ContainerInfo, error)
 
 	var (
 		pod     *Pod
-		c       *hypervisor.Container
+		c       *hypervisor.ContainerStatus
 		i       int = 0
 		imageid string
 		ok      bool

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -175,7 +175,7 @@ func showPodContainers(pod *hypervisor.PodStatus, aux bool) []string {
 	return rsp
 }
 
-func showContainer(c *hypervisor.Container) string {
+func showContainer(c *hypervisor.ContainerStatus) string {
 	var status string
 
 	switch c.Status {

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -1053,6 +1053,8 @@ func (p *Pod) Cleanup(daemon *Daemon) {
 	p.cleanupMountsAndFiles(daemon.Storage, sharedDir)
 	p.cleanupEtcHosts()
 
+	p.status.CleanupExec()
+
 	if p.status.Status == types.S_POD_NONE {
 		daemon.RemovePodResource(p)
 	}

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -38,7 +38,6 @@ type Pod struct {
 	vm           *hypervisor.Vm
 	ctnStartInfo []*hypervisor.ContainerInfo
 	volumes      map[string]*hypervisor.VolumeInfo
-	ttyList      map[string]*hypervisor.TtyIO
 
 	transiting chan bool
 	sync.RWMutex
@@ -286,7 +285,6 @@ func NewPod(podSpec *apitypes.UserPod, id string, data interface{}) (*Pod, error
 
 	p := &Pod{
 		Id:         id,
-		ttyList:    make(map[string]*hypervisor.TtyIO),
 		volumes:    make(map[string]*hypervisor.VolumeInfo),
 		transiting: make(chan bool, 1),
 	}
@@ -1173,10 +1171,6 @@ func (p *Pod) AttachTtys(daemon *Daemon, streams []*hypervisor.TtyIO) (err error
 		if idx >= len(ttyContainers) {
 			break
 		}
-
-		p.Lock()
-		p.ttyList[str.ClientTag] = str
-		p.Unlock()
 
 		err = p.vm.Attach(str, ttyContainers[idx].Id, nil)
 		if err != nil {

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -1147,8 +1147,7 @@ func (p *Pod) startLogging(daemon *Daemon) (err error) {
 	for _, c := range p.status.Containers {
 		var stdout, stderr io.Reader
 
-		tag := "log-" + utils.RandStr(8, "alphanum")
-		if stdout, stderr, err = p.vm.GetLogOutput(c.Id, tag, nil); err != nil {
+		if stdout, stderr, err = p.vm.GetLogOutput(c.Id, nil); err != nil {
 			return
 		}
 		c.Logs.Copier = logger.NewCopier(c.Id, map[string]io.Reader{"stdout": stdout, "stderr": stderr}, c.Logs.Driver)
@@ -1174,12 +1173,13 @@ func (p *Pod) AttachTtys(daemon *Daemon, streams []*hypervisor.TtyIO) (err error
 			break
 		}
 
-		err = p.vm.Attach(str, ttyContainers[idx].Id, nil)
+		containerId := ttyContainers[idx].Id
+		err = p.vm.Attach(str, containerId, nil)
 		if err != nil {
-			glog.Errorf("Failed to attach client %s before start pod", str.ClientTag)
+			glog.Errorf("Failed to attach to container %s before start pod", containerId)
 			return
 		}
-		glog.V(1).Infof("Attach client %s before start pod", str.ClientTag)
+		glog.V(1).Infof("Attach to container %s before start pod", containerId)
 	}
 
 	return nil

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -671,7 +671,7 @@ func (p *Pod) CreateVolumes(daemon *Daemon) error {
 }
 
 func (p *Pod) UpdateContainerStatus(jsons []*dockertypes.ContainerJSON) error {
-	p.status.Containers = []*hypervisor.Container{}
+	p.status.Containers = []*hypervisor.ContainerStatus{}
 	for idx, c := range p.spec.Containers {
 		if jsons[idx] == nil {
 			estr := fmt.Sprintf("container %s of pod %s does not have inspect json", c.Name, p.Id)

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -85,13 +85,7 @@ func (daemon *Daemon) StartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId
 	}
 
 	if len(ttys) > 0 {
-		p.RLock()
-		tty, ok := p.ttyList[tag]
-		p.RUnlock()
-
-		if ok {
-			tty.WaitForFinish()
-		}
+		ttys[0].WaitForFinish()
 	}
 
 	return code, cause, nil

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -52,16 +52,15 @@ func (daemon *Daemon) createPodInternal(podId string, podSpec *apitypes.UserPod,
 	return pod, nil
 }
 
-func (daemon *Daemon) StartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId, vmId, tag string) (int, string, error) {
+func (daemon *Daemon) StartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId, vmId string, attach bool) (int, string, error) {
 	var ttys []*hypervisor.TtyIO = []*hypervisor.TtyIO{}
 
-	if tag != "" {
-		glog.V(1).Info("Pod Run with client terminal tag: ", tag)
+	if attach {
+		glog.V(1).Info("Run pod with tty attached")
 		ttys = append(ttys, &hypervisor.TtyIO{
-			Stdin:     stdin,
-			Stdout:    stdout,
-			ClientTag: tag,
-			Callback:  make(chan *types.VmResponse, 1),
+			Stdin:    stdin,
+			Stdout:   stdout,
+			Callback: make(chan *types.VmResponse, 1),
 		})
 	}
 

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -290,8 +290,8 @@ func (daemon *Daemon) CmdSetPodLabels(podId string, override bool, labels map[st
 	return v, nil
 }
 
-func (daemon *Daemon) CmdStartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId, vmId, tag string) (*engine.Env, error) {
-	code, cause, err := daemon.StartPod(stdin, stdout, podId, vmId, tag)
+func (daemon *Daemon) CmdStartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId, vmId string, attach bool) (*engine.Env, error) {
+	code, cause, err := daemon.StartPod(stdin, stdout, podId, vmId, attach)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -191,10 +191,6 @@ func (daemon *Daemon) CmdStopContainer(name string) (*engine.Env, error) {
 	return v, nil
 }
 
-func (daemon *Daemon) CmdExec(stdin io.ReadCloser, stdout io.WriteCloser, key, id, cmd, tag string, terminal bool) error {
-	return daemon.Exec(stdin, stdout, key, id, cmd, tag, terminal)
-}
-
 func (daemon *Daemon) CmdExitCode(container, tag string) (int, error) {
 	return daemon.ExitCode(container, tag)
 }

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -52,8 +52,8 @@ func (daemon *Daemon) CmdAuthenticateToRegistry(config *types.AuthConfig) (strin
 	return daemon.Daemon.AuthenticateToRegistry(config)
 }
 
-func (daemon *Daemon) CmdAttach(stdin io.ReadCloser, stdout io.WriteCloser, key, id, tag string) error {
-	return daemon.Attach(stdin, stdout, key, id, tag)
+func (daemon *Daemon) CmdAttach(stdin io.ReadCloser, stdout io.WriteCloser, container string) error {
+	return daemon.Attach(stdin, stdout, container)
 }
 
 func (daemon *Daemon) CmdCommitImage(name string, cfg *types.ContainerCommitConfig) (*engine.Env, error) {
@@ -191,8 +191,8 @@ func (daemon *Daemon) CmdStopContainer(name string) (*engine.Env, error) {
 	return v, nil
 }
 
-func (daemon *Daemon) CmdExitCode(container, tag string) (int, error) {
-	return daemon.ExitCode(container, tag)
+func (daemon *Daemon) CmdExitCode(containerId, execId string) (int, error) {
+	return daemon.ExitCode(containerId, execId)
 }
 
 func (daemon *Daemon) CmdSystemInfo() (*apitypes.InfoResponse, error) {
@@ -443,8 +443,8 @@ func (daemon *Daemon) CmdKillPod(podId, container string, sig int64) (*engine.En
 	return v, nil
 }
 
-func (daemon *Daemon) CmdTtyResize(podId, tag string, h, w int) error {
-	return daemon.TtyResize(podId, tag, h, w)
+func (daemon *Daemon) CmdTtyResize(containerId, execId string, h, w int) error {
+	return daemon.TtyResize(containerId, execId, h, w)
 }
 
 func (daemon *Daemon) CmdCreateVm(cpu, mem int, async bool) (*engine.Env, error) {

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -123,8 +123,6 @@ func (daemon *Daemon) StopContainerWithinLock(pod *Pod, containerId string) erro
 		return err
 	}
 
-	pod.status.SetOneContainerStatus(containerId, types.S_POD_FAILED)
-
 	pod.Unlock()
 
 	return nil

--- a/daemon/tty.go
+++ b/daemon/tty.go
@@ -3,34 +3,16 @@ package daemon
 import (
 	"fmt"
 	"github.com/golang/glog"
-	"strings"
 )
 
-func (daemon *Daemon) TtyResize(podId, tag string, h, w int) error {
-	var (
-		container string
-		vmid      string
-		err       error
-	)
-
-	if strings.Contains(podId, "pod-") {
-		container = ""
-		vmid, err = daemon.GetVmByPodId(podId)
-		if err != nil {
-			return err
-		}
-	} else if strings.Contains(podId, "vm-") {
-		vmid = podId
-	} else {
-		container = podId
-		podId, err = daemon.GetPodByContainer(container)
-		if err != nil {
-			return err
-		}
-		vmid, err = daemon.GetVmByPodId(podId)
-		if err != nil {
-			return err
-		}
+func (daemon *Daemon) TtyResize(containerId, execId string, h, w int) error {
+	podId, err := daemon.GetPodByContainer(containerId)
+	if err != nil {
+		return err
+	}
+	vmid, err := daemon.GetVmByPodId(podId)
+	if err != nil {
+		return err
 	}
 
 	vm, ok := daemon.VmList.Get(vmid)
@@ -38,7 +20,7 @@ func (daemon *Daemon) TtyResize(podId, tag string, h, w int) error {
 		return fmt.Errorf("vm %s doesn't exist!", vmid)
 	}
 
-	err = vm.Tty(tag, h, w)
+	err = vm.Tty(containerId, execId, h, w)
 	if err != nil {
 		return err
 	}

--- a/integration/hyper_test.go
+++ b/integration/hyper_test.go
@@ -98,13 +98,13 @@ func (s *TestSuite) TestPostAttach(c *C) {
 	c.Logf("Pod created: %s", pod)
 	defer s.client.RemovePod(pod)
 
-	err = s.client.StartPod(pod, "", "")
+	err = s.client.StartPod(pod, "", false)
 	c.Assert(err, IsNil)
 
 	podInfo, err := s.client.GetPodInfo(pod)
 	c.Assert(err, IsNil)
 
-	err = s.client.PostAttach(podInfo.Status.ContainerStatus[0].ContainerID, "abcdefgh")
+	err = s.client.PostAttach(podInfo.Status.ContainerStatus[0].ContainerID)
 	c.Assert(err, IsNil)
 }
 
@@ -176,7 +176,7 @@ func (s *TestSuite) TestCreateAndStartPod(c *C) {
 		c.Errorf("Can't found pod %s", pod)
 	}
 
-	err = s.client.StartPod(pod, "", "")
+	err = s.client.StartPod(pod, "", false)
 	c.Assert(err, IsNil)
 
 	podInfo, err := s.client.GetPodInfo(pod)
@@ -283,7 +283,7 @@ func (s *TestSuite) TestAddListDeleteService(c *C) {
 		c.Assert(err, IsNil)
 	}()
 
-	err = s.client.StartPod(pod, "", "")
+	err = s.client.StartPod(pod, "", false)
 	c.Assert(err, IsNil)
 
 	updateService := []*types.UserService{
@@ -348,7 +348,7 @@ func (s *TestSuite) TestStartAndStopPod(c *C) {
 	c.Assert(err, IsNil)
 	c.Logf("Pod created: %s", pod)
 
-	err = s.client.StartPod(pod, "", "")
+	err = s.client.StartPod(pod, "", false)
 	c.Assert(err, IsNil)
 
 	podInfo, err := s.client.GetPodInfo(pod)
@@ -408,7 +408,7 @@ func (s *TestSuite) TestPauseAndUnpausePod(c *C) {
 	c.Assert(err, IsNil)
 	c.Logf("Pod created: %s", pod)
 
-	err = s.client.StartPod(pod, "", "")
+	err = s.client.StartPod(pod, "", false)
 	c.Assert(err, IsNil)
 
 	podInfo, err := s.client.GetPodInfo(pod)
@@ -458,7 +458,7 @@ func (s *TestSuite) TestGetPodStats(c *C) {
 		c.Assert(err, IsNil)
 	}()
 
-	err = s.client.StartPod(podID, "", "")
+	err = s.client.StartPod(podID, "", false)
 	c.Assert(err, IsNil)
 
 	stats, err := s.client.GetPodStats(podID)

--- a/server/router/container/backend.go
+++ b/server/router/container/backend.go
@@ -16,7 +16,7 @@ type Backend interface {
 	CmdKillContainer(name string, sig int64) (*engine.Env, error)
 	CmdStopContainer(name string) (*engine.Env, error)
 	CmdContainerRename(oldName, newName string) (*engine.Env, error)
-	CmdAttach(in io.ReadCloser, out io.WriteCloser, key, id, tag string) error
+	CmdAttach(in io.ReadCloser, out io.WriteCloser, id string) error
 	CmdCommitImage(name string, cfg *types.ContainerCommitConfig) (*engine.Env, error)
 	CmdTtyResize(podId, tag string, h, w int) error
 	CreateExec(id, cmd string, terminal bool) (string, error)

--- a/server/router/container/backend.go
+++ b/server/router/container/backend.go
@@ -16,8 +16,9 @@ type Backend interface {
 	CmdKillContainer(name string, sig int64) (*engine.Env, error)
 	CmdStopContainer(name string) (*engine.Env, error)
 	CmdContainerRename(oldName, newName string) (*engine.Env, error)
-	CmdExec(in io.ReadCloser, out io.WriteCloser, key, id, cmd, tag string, terminal bool) error
 	CmdAttach(in io.ReadCloser, out io.WriteCloser, key, id, tag string) error
 	CmdCommitImage(name string, cfg *types.ContainerCommitConfig) (*engine.Env, error)
 	CmdTtyResize(podId, tag string, h, w int) error
+	CreateExec(id, cmd string, terminal bool) (string, error)
+	StartExec(stdin io.ReadCloser, stdout io.WriteCloser, containerId, execId string) error
 }

--- a/server/router/container/container.go
+++ b/server/router/container/container.go
@@ -38,7 +38,8 @@ func (r *containerRouter) initRoutes() {
 		local.NewPostRoute("/container/commit", r.postContainerCommit),
 		local.NewPostRoute("/container/stop", r.postContainerStop),
 		local.NewPostRoute("/container/kill", r.postContainerKill),
-		local.NewPostRoute("/exec", r.postContainerExec),
+		local.NewPostRoute("/exec/create", r.postContainerExecCreate),
+		local.NewPostRoute("/exec/start", r.postContainerExecStart),
 		local.NewPostRoute("/attach", r.postContainerAttach),
 		local.NewPostRoute("/tty/resize", r.postTtyResize),
 		// PUT

--- a/server/router/container/exec.go
+++ b/server/router/container/exec.go
@@ -65,11 +65,7 @@ func (s *containerRouter) postContainerAttach(ctx context.Context, w http.Respon
 		return err
 	}
 
-	key := r.Form.Get("type")
-	id := r.Form.Get("value")
-	tag := r.Form.Get("tag")
-	//remove := r.Form.Get("remove")
-
+	container := r.Form.Get("container")
 	// Setting up the streaming http interface.
 	inStream, outStream, err := httputils.HijackConnection(w)
 	if err != nil {
@@ -79,7 +75,7 @@ func (s *containerRouter) postContainerAttach(ctx context.Context, w http.Respon
 
 	fmt.Fprintf(outStream, "HTTP/1.1 101 UPGRADED\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n")
 
-	return s.backend.CmdAttach(inStream, outStream.(io.WriteCloser), key, id, tag)
+	return s.backend.CmdAttach(inStream, outStream.(io.WriteCloser), container)
 }
 
 func (s *containerRouter) postTtyResize(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -95,8 +91,8 @@ func (s *containerRouter) postTtyResize(ctx context.Context, w http.ResponseWrit
 		return err
 	}
 
-	tag := r.Form.Get("tag")
-	podId := r.Form.Get("id")
+	containerId := r.Form.Get("container")
+	execId := r.Form.Get("exec")
 
-	return s.backend.CmdTtyResize(podId, tag, height, width)
+	return s.backend.CmdTtyResize(containerId, execId, height, width)
 }

--- a/server/router/container/exec.go
+++ b/server/router/container/exec.go
@@ -15,7 +15,7 @@ func (s *containerRouter) getExitCode(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 
-	code, err := s.backend.CmdExitCode(r.Form.Get("container"), r.Form.Get("tag"))
+	code, err := s.backend.CmdExitCode(r.Form.Get("container"), r.Form.Get("exec"))
 	if err != nil {
 		return err
 	}

--- a/server/router/pod/backend.go
+++ b/server/router/pod/backend.go
@@ -13,7 +13,7 @@ type Backend interface {
 	CmdGetPodStats(podId string) (interface{}, error)
 	CmdCreatePod(podArgs string, autoremove bool) (*engine.Env, error)
 	CmdSetPodLabels(podId string, override bool, labels map[string]string) (*engine.Env, error)
-	CmdStartPod(in io.ReadCloser, out io.WriteCloser, podId, vmId, tag string) (*engine.Env, error)
+	CmdStartPod(in io.ReadCloser, out io.WriteCloser, podId, vmId string, attach bool) (*engine.Env, error)
 	CmdPausePod(podId string) error
 	CmdUnpausePod(podId string) error
 	CmdList(item, podId, vmId string, auxiliary bool) (*engine.Env, error)

--- a/serverrpc/attach.go
+++ b/serverrpc/attach.go
@@ -44,5 +44,5 @@ func (s *ServerRPC) Attach(stream types.PublicAPI_AttachServer) error {
 		}
 	}()
 
-	return s.daemon.Attach(ir, ow, "", req.ContainerID, req.Tag)
+	return s.daemon.Attach(ir, ow, req.ContainerID)
 }

--- a/serverrpc/pod.go
+++ b/serverrpc/pod.go
@@ -36,8 +36,8 @@ func (s *ServerRPC) PodStart(stream types.PublicAPI_PodStartServer) error {
 	}
 	glog.V(3).Infof("PodStart with request %s", req.String())
 
-	if req.Tag == "" {
-		_, _, err := s.daemon.StartPod(nil, nil, req.PodID, req.VmID, req.Tag)
+	if !req.Attach {
+		_, _, err := s.daemon.StartPod(nil, nil, req.PodID, req.VmID, req.Attach)
 		if err != nil {
 			glog.Errorf("StartPod failed: %v", err)
 			return err
@@ -82,7 +82,7 @@ func (s *ServerRPC) PodStart(stream types.PublicAPI_PodStartServer) error {
 		}
 	}()
 
-	if _, _, err := s.daemon.StartPod(ir, ow, req.PodID, req.VmID, req.Tag); err != nil {
+	if _, _, err := s.daemon.StartPod(ir, ow, req.PodID, req.VmID, req.Attach); err != nil {
 		glog.Errorf("StartPod failed: %v", err)
 		return err
 	}

--- a/servicediscovery/servicediscovery.go
+++ b/servicediscovery/servicediscovery.go
@@ -83,7 +83,7 @@ func SetupLoopbackAddress(vm *hypervisor.Vm, container, ip, operation string) er
 		ClientTag: utils.RandStr(8, "alphanum"),
 	}
 
-	vm.Pod.AddExec(container, execId, command)
+	vm.Pod.AddExec(container, execId, command, false)
 	defer vm.Pod.DeleteExec(execId)
 
 	if err := vm.Exec(container, execId, string(execcmd), false, tty); err != nil {
@@ -132,7 +132,7 @@ func ApplyServices(vm *hypervisor.Vm, container string, services []pod.UserServi
 		ClientTag: utils.RandStr(8, "alphanum"),
 	}
 
-	vm.Pod.AddExec(container, execId, string(execcmd))
+	vm.Pod.AddExec(container, execId, string(execcmd), false)
 	defer vm.Pod.DeleteExec(execId)
 
 	if err := vm.Exec(container, execId, string(execcmd), false, tty); err != nil {

--- a/servicediscovery/servicediscovery.go
+++ b/servicediscovery/servicediscovery.go
@@ -79,8 +79,7 @@ func SetupLoopbackAddress(vm *hypervisor.Vm, container, ip, operation string) er
 	}
 
 	tty := &hypervisor.TtyIO{
-		Callback:  make(chan *types.VmResponse, 1),
-		ClientTag: utils.RandStr(8, "alphanum"),
+		Callback: make(chan *types.VmResponse, 1),
 	}
 
 	vm.Pod.AddExec(container, execId, command, false)
@@ -128,8 +127,7 @@ func ApplyServices(vm *hypervisor.Vm, container string, services []pod.UserServi
 	}
 
 	tty := &hypervisor.TtyIO{
-		Callback:  make(chan *types.VmResponse, 1),
-		ClientTag: utils.RandStr(8, "alphanum"),
+		Callback: make(chan *types.VmResponse, 1),
 	}
 
 	vm.Pod.AddExec(container, execId, string(execcmd), false)

--- a/types/types.pb.go
+++ b/types/types.pb.go
@@ -1488,10 +1488,10 @@ func (m *ExecStartResponse) String() string { return proto.CompactTextString(m) 
 func (*ExecStartResponse) ProtoMessage()    {}
 
 type PodStartMessage struct {
-	PodID string `protobuf:"bytes,1,opt,name=podID,proto3" json:"podID,omitempty"`
-	VmID  string `protobuf:"bytes,2,opt,name=vmID,proto3" json:"vmID,omitempty"`
-	Tag   string `protobuf:"bytes,3,opt,name=tag,proto3" json:"tag,omitempty"`
-	Data  []byte `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"`
+	PodID  string `protobuf:"bytes,1,opt,name=podID,proto3" json:"podID,omitempty"`
+	VmID   string `protobuf:"bytes,2,opt,name=vmID,proto3" json:"vmID,omitempty"`
+	Attach bool   `protobuf:"varint,3,opt,name=attach,proto3" json:"attach,omitempty"`
+	Data   []byte `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"`
 }
 
 func (m *PodStartMessage) Reset()         { *m = PodStartMessage{} }

--- a/types/types.pb.go
+++ b/types/types.pb.go
@@ -1518,8 +1518,7 @@ func (*WaitResponse) ProtoMessage()    {}
 
 type AttachMessage struct {
 	ContainerID string `protobuf:"bytes,1,opt,name=containerID,proto3" json:"containerID,omitempty"`
-	Tag         string `protobuf:"bytes,2,opt,name=tag,proto3" json:"tag,omitempty"`
-	Data        []byte `protobuf:"bytes,3,opt,name=data,proto3" json:"data,omitempty"`
+	Data        []byte `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
 }
 
 func (m *AttachMessage) Reset()         { *m = AttachMessage{} }

--- a/types/types.pb.go
+++ b/types/types.pb.go
@@ -79,8 +79,10 @@ It has these top-level messages:
 	DriverStatus
 	InfoRequest
 	InfoResponse
-	ContainerExecRequest
-	ContainerExecResponse
+	ExecCreateRequest
+	ExecCreateResponse
+	ExecStartRequest
+	ExecStartResponse
 	PodStartMessage
 	WaitRequest
 	WaitResponse
@@ -1449,25 +1451,41 @@ func (m *InfoResponse) GetDstatus() []*DriverStatus {
 	return nil
 }
 
-type ContainerExecRequest struct {
+type ExecCreateRequest struct {
 	ContainerID string   `protobuf:"bytes,1,opt,name=containerID,proto3" json:"containerID,omitempty"`
 	Command     []string `protobuf:"bytes,2,rep,name=command" json:"command,omitempty"`
-	Tag         string   `protobuf:"bytes,3,opt,name=tag,proto3" json:"tag,omitempty"`
-	Tty         bool     `protobuf:"varint,4,opt,name=tty,proto3" json:"tty,omitempty"`
-	Stdin       []byte   `protobuf:"bytes,5,opt,name=stdin,proto3" json:"stdin,omitempty"`
+	Tty         bool     `protobuf:"varint,3,opt,name=tty,proto3" json:"tty,omitempty"`
 }
 
-func (m *ContainerExecRequest) Reset()         { *m = ContainerExecRequest{} }
-func (m *ContainerExecRequest) String() string { return proto.CompactTextString(m) }
-func (*ContainerExecRequest) ProtoMessage()    {}
+func (m *ExecCreateRequest) Reset()         { *m = ExecCreateRequest{} }
+func (m *ExecCreateRequest) String() string { return proto.CompactTextString(m) }
+func (*ExecCreateRequest) ProtoMessage()    {}
 
-type ContainerExecResponse struct {
+type ExecCreateResponse struct {
+	ExecID string `protobuf:"bytes,1,opt,name=execID,proto3" json:"execID,omitempty"`
+}
+
+func (m *ExecCreateResponse) Reset()         { *m = ExecCreateResponse{} }
+func (m *ExecCreateResponse) String() string { return proto.CompactTextString(m) }
+func (*ExecCreateResponse) ProtoMessage()    {}
+
+type ExecStartRequest struct {
+	ContainerID string `protobuf:"bytes,1,opt,name=containerID,proto3" json:"containerID,omitempty"`
+	ExecID      string `protobuf:"bytes,2,opt,name=execID,proto3" json:"execID,omitempty"`
+	Stdin       []byte `protobuf:"bytes,3,opt,name=stdin,proto3" json:"stdin,omitempty"`
+}
+
+func (m *ExecStartRequest) Reset()         { *m = ExecStartRequest{} }
+func (m *ExecStartRequest) String() string { return proto.CompactTextString(m) }
+func (*ExecStartRequest) ProtoMessage()    {}
+
+type ExecStartResponse struct {
 	Stdout []byte `protobuf:"bytes,1,opt,name=stdout,proto3" json:"stdout,omitempty"`
 }
 
-func (m *ContainerExecResponse) Reset()         { *m = ContainerExecResponse{} }
-func (m *ContainerExecResponse) String() string { return proto.CompactTextString(m) }
-func (*ContainerExecResponse) ProtoMessage()    {}
+func (m *ExecStartResponse) Reset()         { *m = ExecStartResponse{} }
+func (m *ExecStartResponse) String() string { return proto.CompactTextString(m) }
+func (*ExecStartResponse) ProtoMessage()    {}
 
 type PodStartMessage struct {
 	PodID string `protobuf:"bytes,1,opt,name=podID,proto3" json:"podID,omitempty"`
@@ -1935,8 +1953,10 @@ func init() {
 	proto.RegisterType((*DriverStatus)(nil), "types.DriverStatus")
 	proto.RegisterType((*InfoRequest)(nil), "types.InfoRequest")
 	proto.RegisterType((*InfoResponse)(nil), "types.InfoResponse")
-	proto.RegisterType((*ContainerExecRequest)(nil), "types.ContainerExecRequest")
-	proto.RegisterType((*ContainerExecResponse)(nil), "types.ContainerExecResponse")
+	proto.RegisterType((*ExecCreateRequest)(nil), "types.ExecCreateRequest")
+	proto.RegisterType((*ExecCreateResponse)(nil), "types.ExecCreateResponse")
+	proto.RegisterType((*ExecStartRequest)(nil), "types.ExecStartRequest")
+	proto.RegisterType((*ExecStartResponse)(nil), "types.ExecStartResponse")
 	proto.RegisterType((*PodStartMessage)(nil), "types.PodStartMessage")
 	proto.RegisterType((*WaitRequest)(nil), "types.WaitRequest")
 	proto.RegisterType((*WaitResponse)(nil), "types.WaitResponse")
@@ -2028,8 +2048,10 @@ type PublicAPIClient interface {
 	// TODO: ContainerLabels updates labels of the specified container
 	// ContainerStop stops the specified container
 	ContainerStop(ctx context.Context, in *ContainerStopRequest, opts ...grpc.CallOption) (*ContainerStopResponse, error)
-	// ContainerExec execs a command in specified container
-	ContainerExec(ctx context.Context, opts ...grpc.CallOption) (PublicAPI_ContainerExecClient, error)
+	// ExecCreate creates exec in specified container
+	ExecCreate(ctx context.Context, in *ExecCreateRequest, opts ...grpc.CallOption) (*ExecCreateResponse, error)
+	// ExecStart starts exec
+	ExecStart(ctx context.Context, opts ...grpc.CallOption) (PublicAPI_ExecStartClient, error)
 	// Attach attaches to the specified container
 	Attach(ctx context.Context, opts ...grpc.CallOption) (PublicAPI_AttachClient, error)
 	// Wait gets the exit code of the specified container
@@ -2288,31 +2310,40 @@ func (c *publicAPIClient) ContainerStop(ctx context.Context, in *ContainerStopRe
 	return out, nil
 }
 
-func (c *publicAPIClient) ContainerExec(ctx context.Context, opts ...grpc.CallOption) (PublicAPI_ContainerExecClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_PublicAPI_serviceDesc.Streams[2], c.cc, "/types.PublicAPI/ContainerExec", opts...)
+func (c *publicAPIClient) ExecCreate(ctx context.Context, in *ExecCreateRequest, opts ...grpc.CallOption) (*ExecCreateResponse, error) {
+	out := new(ExecCreateResponse)
+	err := grpc.Invoke(ctx, "/types.PublicAPI/ExecCreate", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &publicAPIContainerExecClient{stream}
+	return out, nil
+}
+
+func (c *publicAPIClient) ExecStart(ctx context.Context, opts ...grpc.CallOption) (PublicAPI_ExecStartClient, error) {
+	stream, err := grpc.NewClientStream(ctx, &_PublicAPI_serviceDesc.Streams[2], c.cc, "/types.PublicAPI/ExecStart", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &publicAPIExecStartClient{stream}
 	return x, nil
 }
 
-type PublicAPI_ContainerExecClient interface {
-	Send(*ContainerExecRequest) error
-	Recv() (*ContainerExecResponse, error)
+type PublicAPI_ExecStartClient interface {
+	Send(*ExecStartRequest) error
+	Recv() (*ExecStartResponse, error)
 	grpc.ClientStream
 }
 
-type publicAPIContainerExecClient struct {
+type publicAPIExecStartClient struct {
 	grpc.ClientStream
 }
 
-func (x *publicAPIContainerExecClient) Send(m *ContainerExecRequest) error {
+func (x *publicAPIExecStartClient) Send(m *ExecStartRequest) error {
 	return x.ClientStream.SendMsg(m)
 }
 
-func (x *publicAPIContainerExecClient) Recv() (*ContainerExecResponse, error) {
-	m := new(ContainerExecResponse)
+func (x *publicAPIExecStartClient) Recv() (*ExecStartResponse, error) {
+	m := new(ExecStartResponse)
 	if err := x.ClientStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
@@ -2533,8 +2564,10 @@ type PublicAPIServer interface {
 	// TODO: ContainerLabels updates labels of the specified container
 	// ContainerStop stops the specified container
 	ContainerStop(context.Context, *ContainerStopRequest) (*ContainerStopResponse, error)
-	// ContainerExec execs a command in specified container
-	ContainerExec(PublicAPI_ContainerExecServer) error
+	// ExecCreate creates exec in specified container
+	ExecCreate(context.Context, *ExecCreateRequest) (*ExecCreateResponse, error)
+	// ExecStart starts exec
+	ExecStart(PublicAPI_ExecStartServer) error
 	// Attach attaches to the specified container
 	Attach(PublicAPI_AttachServer) error
 	// Wait gets the exit code of the specified container
@@ -2827,26 +2860,38 @@ func _PublicAPI_ContainerStop_Handler(srv interface{}, ctx context.Context, dec 
 	return out, nil
 }
 
-func _PublicAPI_ContainerExec_Handler(srv interface{}, stream grpc.ServerStream) error {
-	return srv.(PublicAPIServer).ContainerExec(&publicAPIContainerExecServer{stream})
+func _PublicAPI_ExecCreate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(ExecCreateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(PublicAPIServer).ExecCreate(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
-type PublicAPI_ContainerExecServer interface {
-	Send(*ContainerExecResponse) error
-	Recv() (*ContainerExecRequest, error)
+func _PublicAPI_ExecStart_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(PublicAPIServer).ExecStart(&publicAPIExecStartServer{stream})
+}
+
+type PublicAPI_ExecStartServer interface {
+	Send(*ExecStartResponse) error
+	Recv() (*ExecStartRequest, error)
 	grpc.ServerStream
 }
 
-type publicAPIContainerExecServer struct {
+type publicAPIExecStartServer struct {
 	grpc.ServerStream
 }
 
-func (x *publicAPIContainerExecServer) Send(m *ContainerExecResponse) error {
+func (x *publicAPIExecStartServer) Send(m *ExecStartResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func (x *publicAPIContainerExecServer) Recv() (*ContainerExecRequest, error) {
-	m := new(ContainerExecRequest)
+func (x *publicAPIExecStartServer) Recv() (*ExecStartRequest, error) {
+	m := new(ExecStartRequest)
 	if err := x.ServerStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
@@ -3094,6 +3139,10 @@ var _PublicAPI_serviceDesc = grpc.ServiceDesc{
 			Handler:    _PublicAPI_ContainerStop_Handler,
 		},
 		{
+			MethodName: "ExecCreate",
+			Handler:    _PublicAPI_ExecCreate_Handler,
+		},
+		{
 			MethodName: "Wait",
 			Handler:    _PublicAPI_Wait_Handler,
 		},
@@ -3139,8 +3188,8 @@ var _PublicAPI_serviceDesc = grpc.ServiceDesc{
 			ServerStreams: true,
 		},
 		{
-			StreamName:    "ContainerExec",
-			Handler:       _PublicAPI_ContainerExec_Handler,
+			StreamName:    "ExecStart",
+			Handler:       _PublicAPI_ExecStart_Handler,
 			ServerStreams: true,
 			ClientStreams: true,
 		},

--- a/types/types.proto
+++ b/types/types.proto
@@ -531,15 +531,23 @@ message InfoResponse {
   string  name                    = 12;
 }
 
-message ContainerExecRequest{
+message ExecCreateRequest{
     string containerID      = 1;
     repeated string command = 2;
-    string tag              = 3;
-    bool   tty              = 4;
-    bytes  stdin            = 5;
+    bool   tty              = 3;
 }
 
-message ContainerExecResponse{
+message ExecCreateResponse{
+    string execID = 1;
+}
+
+message ExecStartRequest{
+    string containerID      = 1;
+    string execID           = 2;
+    bytes  stdin            = 3;
+}
+
+message ExecStartResponse{
     bytes stdout = 1;
 }
 
@@ -759,8 +767,10 @@ service PublicAPI {
     // TODO: ContainerLabels updates labels of the specified container
     // ContainerStop stops the specified container
     rpc ContainerStop(ContainerStopRequest) returns (ContainerStopResponse) {}
-    // ContainerExec execs a command in specified container
-    rpc ContainerExec(stream ContainerExecRequest) returns (stream ContainerExecResponse) {}
+    // ExecCreate creates exec in specified container
+    rpc ExecCreate(ExecCreateRequest) returns (ExecCreateResponse) {}
+    // ExecStart starts exec
+    rpc ExecStart(stream ExecStartRequest) returns (stream ExecStartResponse) {}
     // Attach attaches to the specified container
     rpc Attach(stream AttachMessage) returns (stream AttachMessage) {}
     // Wait gets the exit code of the specified container

--- a/types/types.proto
+++ b/types/types.proto
@@ -554,7 +554,7 @@ message ExecStartResponse{
 message PodStartMessage {
   string podID  = 1;
   string vmID   = 2;
-  string tag    = 3;
+  bool   attach = 3;
   bytes  data   = 4;
 }
 

--- a/types/types.proto
+++ b/types/types.proto
@@ -570,8 +570,7 @@ message WaitResponse{
 
 message AttachMessage {
   string containerID   = 1;
-  string tag           = 2;
-  bytes  data          = 3;
+  bytes  data          = 2;
 }
 
 message ContainerCreateRequest {


### PR DESCRIPTION
Note: The api below is changed
```
/exec?type=container&value=containerId&command=command&tag=tagId&tty=yes ->
/exec/create?container=containerId&command=command&tty=yes(return execId)
/exec/start?container=containerId&exec=execId
```
```
/exit?container=containerId&tag=tagId -> container=containerId&exec=execId
```
```
/pod/start?podId=podId&vmId=vmId&tag=tagId -> podId=podId&vmId=vmId&attach=yes
```
```
/attach?type="container"&value=containerId&tag=tagId -> container=containerId
```
```
/resize?id=containerId&tag=tagId&h=23&w=23 -> container=containerId&exec=execId&h=23&w=23
```

base on https://github.com/hyperhq/runv/pull/268