### PR TITLE
logs Improve: procedure adjust and path configurable 

### DIFF
--- a/client/api/interface.go
+++ b/client/api/interface.go
@@ -22,7 +22,7 @@ type APIInterface interface {
 	GetContainerInfo(container string) (*types.ContainerInfo, error)
 	GetContainerByPod(podId string) (string, error)
 	GetExitCode(container, tag string) error
-	ContainerLogs(container, since string, timestamp, follow bool, tail string) (io.ReadCloser, string, error)
+	ContainerLogs(container, since string, timestamp, follow, stdout, stderr bool, tail string) (io.ReadCloser, string, error)
 	KillContainer(container string, sig int) error
 	StopContainer(container string) error
 

--- a/client/api/logs.go
+++ b/client/api/logs.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 )
 
-func (cli *Client) ContainerLogs(container, since string, timestamp, follow bool, tail string) (io.ReadCloser, string, error) {
+func (cli *Client) ContainerLogs(container, since string, timestamp, follow, stdout, stderr bool, tail string) (io.ReadCloser, string, error) {
 	v := url.Values{}
 	v.Set("container", container)
-	v.Set("stdout", "yes")
-	v.Set("stderr", "yes")
+	v.Set("stdout", strconv.FormatBool(stdout))
+	v.Set("stderr", strconv.FormatBool(stderr))
 	v.Set("since", since)
 	v.Set("timestamps", strconv.FormatBool(timestamp))
 	v.Set("follow", strconv.FormatBool(follow))

--- a/client/logs.go
+++ b/client/logs.go
@@ -36,7 +36,7 @@ func (cli *HyperClient) HyperCmdLogs(args ...string) error {
 		return err
 	}
 
-	output, ctype, err := cli.client.ContainerLogs(args[0], opts.Since, opts.Times, opts.Follow, opts.Tail)
+	output, ctype, err := cli.client.ContainerLogs(args[0], opts.Since, opts.Times, opts.Follow, true, true, opts.Tail)
 	if err != nil {
 		return err
 	}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/daemon/logger"
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/golang/glog"
 	"github.com/hyperhq/runv/hypervisor/types"
@@ -36,17 +37,9 @@ func (daemon *Daemon) GetContainerLogs(container string, config *ContainerLogsCo
 		tailLines int
 	)
 
-	outStream := config.OutStream
-	errStream := outStream
-
 	pod, cidx, err = daemon.GetPodByContainerIdOrName(container)
 	if err != nil {
 		return err
-	}
-
-	if !pod.spec.Containers[cidx].Tty {
-		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
-		errStream = stdcopy.NewStdWriter(config.OutStream, stdcopy.Stderr)
 	}
 
 	err = pod.getLogger(daemon)
@@ -72,6 +65,18 @@ func (daemon *Daemon) GetContainerLogs(container string, config *ContainerLogsCo
 	}
 
 	logs := logReader.ReadLogs(readConfig)
+
+	wf := ioutils.NewWriteFlusher(config.OutStream)
+	defer wf.Close()
+	wf.Flush()
+
+	var outStream io.Writer = wf
+	errStream := outStream
+	if !pod.spec.Containers[cidx].Tty {
+		errStream = stdcopy.NewStdWriter(outStream, stdcopy.Stderr)
+		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
+	}
+
 	for {
 		select {
 		case <-config.Stop:
@@ -82,6 +87,7 @@ func (daemon *Daemon) GetContainerLogs(container string, config *ContainerLogsCo
 		case msg, ok := <-logs.Msg:
 			if !ok {
 				glog.V(1).Info("logs: end stream")
+				logs.Close()
 				return nil
 			}
 			logLine := msg.Line

--- a/package/dist/etc/hyper/config
+++ b/package/dist/etc/hyper/config
@@ -53,3 +53,7 @@ Cbfs=/var/lib/hyper/cbfs-qboot.rom
 # It is recommended to specify the "cache" when VmFactoryPolicy is set,
 # otherwise it is a less efficient factory
 VmFactoryPolicy=
+
+[Log]
+# PodLogPrefix=/var/run/hyper/Pods
+# PodIdInPath=true


### PR DESCRIPTION
make logs api works like docker logs exactly.

and 

make container logs dir configurable

The default is not changed: `/var/run/hyper/Pods/{Pod ID}/{container ID}-json.log`

Default config (Log section in `/etc/hyper/config`)

```
[Log]
# PodLogPrefix=/var/run/hyper/Pods
# PodIdInPath=true
```

If configure as

```
[Log]
PodLogPrefix=/var/run/hyper/containers
PodIdInPath=false
```

logs will appear in `/var/run/hyper/containers/{container ID}-json.log`
