### PR TITLE
Enable using pod-name in hyperctl commands

### DIFF
--- a/client/api/interface.go
+++ b/client/api/interface.go
@@ -29,7 +29,7 @@ type APIInterface interface {
 	GetPodInfo(podName string) (*types.PodInfo, error)
 	CreatePod(spec interface{}) (string, int, error)
 	StartPod(podId, vmId string, attach, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) (string, error)
-	StopPod(podId, stopVm string) (int, string, error)
+	StopPod(podIdOrName, stopVm string) (int, string, error)
 	RmPod(id string) error
 	PausePod(podId string) error
 	UnpausePod(podId string) error

--- a/client/api/stop.go
+++ b/client/api/stop.go
@@ -19,9 +19,9 @@ func (cli *Client) StopContainer(container string) error {
 	return nil
 }
 
-func (cli *Client) StopPod(podId, stopVm string) (int, string, error) {
+func (cli *Client) StopPod(podIdOrName, stopVm string) (int, string, error) {
 	v := url.Values{}
-	v.Set("podId", podId)
+	v.Set("podIdOrName", podIdOrName)
 	v.Set("stopVm", stopVm)
 	body, _, err := readBody(cli.call("POST", "/pod/stop?"+v.Encode(), nil, nil))
 	if err != nil {

--- a/client/stop.go
+++ b/client/stop.go
@@ -26,7 +26,7 @@ func (cli *HyperClient) HyperCmdStop(args ...string) error {
 		}
 	}
 	if len(args) == 0 {
-		return fmt.Errorf("\"stop\" requires a minimum of 1 argument, please provide POD ID.\n")
+		return fmt.Errorf("\"stop\" requires a minimum of 1 argument, please provide POD ID or POD Name.\n")
 	}
 
 	stopVm := "yes"

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -176,7 +176,7 @@ func (daemon *Daemon) GetPodStats(podId string) (interface{}, error) {
 		ok  bool
 	)
 	if strings.Contains(podId, "pod-") {
-		pod, ok = daemon.PodList.Get(podId)
+		pod, ok = daemon.PodList.GetByIdOrName(podId)
 		if !ok {
 			return nil, fmt.Errorf("Can not get Pod stats with pod ID(%s)", podId)
 		}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -15,7 +15,7 @@ func (daemon *Daemon) ListVMs(podId, vmId string) ([]*hypervisor.Vm, error) {
 
 	if podId != "" {
 		var ok bool
-		pod, ok = daemon.PodList.Get(podId)
+		pod, ok = daemon.PodList.GetByIdOrName(podId)
 		if !ok || (pod == nil) {
 			return nil, fmt.Errorf("Cannot find specified pod %s", podId)
 		}
@@ -58,7 +58,7 @@ func (daemon *Daemon) ListPods(podId, vmId string) ([]*Pod, error) {
 
 	if podId != "" {
 		var ok bool
-		pod, ok = daemon.PodList.Get(podId)
+		pod, ok = daemon.PodList.GetByIdOrName(podId)
 		if !ok || (pod == nil) {
 			return nil, fmt.Errorf("Cannot find specified pod %s", podId)
 		}
@@ -123,7 +123,7 @@ func (daemon *Daemon) ListContainers(podId, vmId string, auxiliary bool) ([]*hyp
 
 	if podId != "" {
 		var ok bool
-		pod, ok = daemon.PodList.Get(podId)
+		pod, ok = daemon.PodList.GetByIdOrName(podId)
 		if !ok || (pod == nil) {
 			return nil, fmt.Errorf("Cannot find specified pod %s", podId)
 		}

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (daemon Daemon) PausePod(podId string) error {
-	pod, ok := daemon.PodList.Get(podId)
+	pod, ok := daemon.PodList.GetByIdOrName(podId)
 	if !ok {
 		return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
 	}
@@ -47,7 +47,7 @@ func (daemon Daemon) PauseContainer(container string) error {
 }
 
 func (daemon *Daemon) UnpausePod(podId string) error {
-	pod, ok := daemon.PodList.Get(podId)
+	pod, ok := daemon.PodList.GetByIdOrName(podId)
 	if !ok {
 		return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
 	}

--- a/daemon/podlist.go
+++ b/daemon/podlist.go
@@ -77,6 +77,14 @@ func (pl *PodList) GetByName(name string) (*Pod, bool) {
 	return nil, false
 }
 
+func (pl *PodList) GetByIdOrName(podIdOrName string) (*Pod, bool) {
+	if strings.Contains(podIdOrName, "pod-") {
+		return pl.Get(podIdOrName)
+	} else {
+		return pl.GetByName(podIdOrName)
+	}
+}
+
 func (pl *PodList) GetByContainerId(cid string) (*Pod, bool) {
 	pl.mu.RLock()
 	defer pl.mu.RUnlock()

--- a/daemon/rm.go
+++ b/daemon/rm.go
@@ -18,7 +18,7 @@ func (daemon *Daemon) CleanPod(podId string) (int, string, error) {
 		err   error
 	)
 
-	pod, ok := daemon.PodList.Get(podId)
+	pod, ok := daemon.PodList.GetByIdOrName(podId)
 	if !ok {
 		return -1, "", fmt.Errorf("Can not find that Pod(%s)", podId)
 	}

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -66,7 +66,7 @@ func (daemon *Daemon) StartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId
 
 	glog.Infof("pod:%s, vm:%s", podId, vmId)
 
-	p, ok := daemon.PodList.Get(podId)
+	p, ok := daemon.PodList.GetByIdOrName(podId)
 	if !ok {
 		return -1, "", fmt.Errorf("The pod(%s) can not be found, please create it first", podId)
 	}
@@ -117,7 +117,7 @@ func (daemon *Daemon) StartInternal(p *Pod, vmId string, config interface{}, laz
 func (daemon *Daemon) RestartPod(mypod *hypervisor.PodStatus) error {
 	// Remove the pod
 	// The pod is stopped, the vm is gone
-	pod, ok := daemon.PodList.Get(mypod.Id)
+	pod, ok := daemon.PodList.GetByIdOrName(mypod.Id)
 	if ok {
 		daemon.RemovePodContainer(pod)
 	}
@@ -156,7 +156,7 @@ func (daemon *Daemon) SetPodLabels(podId string, override bool, labels map[strin
 	var pod *Pod
 	var ok bool
 	if strings.Contains(podId, "pod-") {
-		pod, ok = daemon.PodList.Get(podId)
+		pod, ok = daemon.PodList.GetByIdOrName(podId)
 		if !ok {
 			return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
 		}

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -417,8 +417,8 @@ func (daemon *Daemon) CmdImagePush(repo, tag string, authConfig *types.AuthConfi
 	return daemon.Daemon.PushImage(ref, metaHeaders, authConfig, output)
 }
 
-func (daemon *Daemon) CmdStopPod(podId, stopVm string) (*engine.Env, error) {
-	code, cause, err := daemon.StopPod(podId)
+func (daemon *Daemon) CmdStopPod(podIdOrName, stopVm string) (*engine.Env, error) {
+	code, cause, err := daemon.StopPod(podIdOrName)
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +426,7 @@ func (daemon *Daemon) CmdStopPod(podId, stopVm string) (*engine.Env, error) {
 	// Prepare the VM status to client
 	v := &engine.Env{}
 
-	v.Set("ID", podId)
+	v.Set("ID", podIdOrName)
 	v.SetInt("Code", code)
 	v.Set("Cause", cause)
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -11,7 +11,7 @@ import (
 
 func (daemon *Daemon) PodStopped(podId string) {
 	// find the vm id which running POD, and stop it
-	pod, ok := daemon.PodList.Get(podId)
+	pod, ok := daemon.PodList.GetByIdOrName(podId)
 	if !ok {
 		glog.Errorf("Can not find pod(%s)", podId)
 		return
@@ -27,7 +27,7 @@ func (daemon *Daemon) PodStopped(podId string) {
 
 func (daemon *Daemon) PodWait(podId string) {
 	// find the vm id which running POD, and stop it
-	pod, ok := daemon.PodList.Get(podId)
+	pod, ok := daemon.PodList.GetByIdOrName(podId)
 	if !ok {
 		glog.Errorf("Can not find pod(%s)", podId)
 		return
@@ -48,17 +48,10 @@ func (daemon *Daemon) PodWait(podId string) {
 func (daemon *Daemon) StopPod(podIdOrName string) (int, string, error) {
 	glog.Infof("Prepare to stop the POD: %s", podIdOrName)
 	// find the vm id which running POD, and stop it
-	var pod *Pod
-	var ok bool
-	pod, ok = daemon.PodList.Get(podIdOrName)
+	pod, ok := daemon.PodList.GetByIdOrName(podIdOrName)
 	if !ok {
-		// Can't find it via id, try name
-		pod, ok = daemon.PodList.GetByName(podIdOrName)
-
-		if !ok {
-			glog.Errorf("Can not find pod(%s)", podIdOrName)
-			return -1, "", fmt.Errorf("Can not find pod(%s)", podIdOrName)
-		}
+		glog.Errorf("Can not find pod(%s)", podIdOrName)
+		return -1, "", fmt.Errorf("Can not find pod(%s)", podIdOrName)
 	}
 
 	if !pod.TransitionLock("stop") {

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -45,8 +45,8 @@ func (daemon *Daemon) PodWait(podId string) {
 	pod.Unlock()
 }
 
-func (daemon *Daemon) StopPod(podId string) (int, string, error) {
-	glog.Infof("Prepare to stop the POD: %s", podId)
+func (daemon *Daemon) StopPod(podIdOrName string) (int, string, error) {
+	glog.Infof("Prepare to stop the POD: %s", podIdOrName)
 	// find the vm id which running POD, and stop it
 	var pod *Pod
 	var ok bool
@@ -62,8 +62,8 @@ func (daemon *Daemon) StopPod(podId string) (int, string, error) {
 	}
 
 	if !pod.TransitionLock("stop") {
-		glog.Errorf("Pod %s is under other operation", podId)
-		return -1, "", fmt.Errorf("Pod %s is under other operation", podId)
+		glog.Errorf("Pod %s is under other operation", podIdOrName)
+		return -1, "", fmt.Errorf("Pod %s is under other operation", podIdOrName)
 	}
 	defer pod.TransitionUnlock("stop")
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -48,10 +48,17 @@ func (daemon *Daemon) PodWait(podId string) {
 func (daemon *Daemon) StopPod(podId string) (int, string, error) {
 	glog.Infof("Prepare to stop the POD: %s", podId)
 	// find the vm id which running POD, and stop it
-	pod, ok := daemon.PodList.Get(podId)
+	var pod *Pod
+	var ok bool
+	pod, ok = daemon.PodList.Get(podIdOrName)
 	if !ok {
-		glog.Errorf("Can not find pod(%s)", podId)
-		return -1, "", fmt.Errorf("Can not find pod(%s)", podId)
+		// Can't find it via id, try name
+		pod, ok = daemon.PodList.GetByName(podIdOrName)
+
+		if !ok {
+			glog.Errorf("Can not find pod(%s)", podIdOrName)
+			return -1, "", fmt.Errorf("Can not find pod(%s)", podIdOrName)
+		}
 	}
 
 	if !pod.TransitionLock("stop") {

--- a/server/router/pod/pod_routes.go
+++ b/server/router/pod/pod_routes.go
@@ -157,10 +157,10 @@ func (p *podRouter) postPodStop(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	podId := r.Form.Get("podId")
+	podIdOrName := r.Form.Get("podIdOrName")
 	stopVm := r.Form.Get("stopVm")
 
-	env, err := p.backend.CmdStopPod(podId, stopVm)
+	env, err := p.backend.CmdStopPod(podIdOrName, stopVm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR enables using pod-name in hyperctl commands, which contains those changes:
- A new function in `PodList` struct, which chooses correct scope (Id or Name) to query `Pod` object based on prefix.
- Replace `PodList.Get` in commands to new function.

Please help to review, thanks.
