### PR TITLE
deprecate the flag --nondaemon

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -48,8 +48,7 @@ function start_hyperd()
   sudo "${HYPER_OUTPUT_HOSTBIN}/hyperd" \
     --host="tcp://127.0.0.1:${API_PORT}" \
     --v=3 \
-    --config="${config}" \
-    --nondaemon 1>&2 &
+    --config="${config}" 1>&2 &
   HYPERD_PID=$!
 
   if [ "$sdriver" == "devicemapper" ]; then

--- a/hyperd.go
+++ b/hyperd.go
@@ -22,8 +22,6 @@ import (
 	"github.com/hyperhq/runv/hypervisor"
 
 	"github.com/docker/docker/pkg/parsers/kernel"
-	runvutils "github.com/hyperhq/runv/lib/utils"
-	"github.com/kardianos/osext"
 )
 
 type Options struct {
@@ -50,7 +48,7 @@ func main() {
 		return
 	}
 
-	fnd := flag.Bool("nondaemon", false, "Not daemonize")
+	fnd := flag.Bool("nondaemon", false, "[deprecated flag]") // TODO: remove it when 0.8 is released
 	flDisableIptables := flag.Bool("noniptables", false, "Don't enable iptables rules")
 	flConfig := flag.String("config", "", "Config file for hyperd")
 	flHost := flag.String("host", "", "Host for hyperd")
@@ -67,20 +65,8 @@ func main() {
 		return
 	}
 
-	if !*fnd {
-		path, err := osext.Executable()
-		if err != nil {
-			fmt.Printf("cannot find self executable path for %s: %v\n", os.Args[0], err)
-			os.Exit(-1)
-		}
-
-		_, err = runvutils.ExecInDaemon(path, append([]string{os.Args[0], "--nondaemon"}, os.Args[1:]...))
-		if err != nil {
-			fmt.Println("failed to daemonize hyperd")
-			os.Exit(-1)
-		}
-
-		return
+	if *fnd {
+		fmt.Printf("flag --nondaemon is deprecated\n")
 	}
 
 	var opt = &Options{
@@ -99,7 +85,6 @@ func printHelp() {
   %s [OPTIONS]
 
 Application Options:
-  --nondaemon            Not daemonize
   --config=""            Configuration for %s
   --v=0                  Log level for V logs
   --log_dir              Log directory

--- a/mac_installer/dist/opt/hyper/static/config/sh.hyper.hyper.plist
+++ b/mac_installer/dist/opt/hyper/static/config/sh.hyper.hyper.plist
@@ -10,7 +10,6 @@
 		<string>--config=/opt/hyper/etc/hyper/config</string>
 		<string>--log_dir=/var/log/hyper/</string>
 		<string>-v=1</string>
-		<string>--nondaemon</string>
   </array>
   <key>EnvironmentVariables</key>
   <dict>

--- a/package/dist/lib/systemd/system/hyperd.service
+++ b/package/dist/lib/systemd/system/hyperd.service
@@ -5,7 +5,7 @@ After=network.target
 Requires=
 
 [Service]
-ExecStart=/usr/bin/hyperd --nondaemon --log_dir=/var/log/hyper
+ExecStart=/usr/bin/hyperd --log_dir=/var/log/hyper
 MountFlags=shared
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
The new bahavior is the same as the --nondaemon is always set.

If the user want to launch hyperd as system daemon,
the user should use the system daemon tools such as systemd.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>