### PR TITLE
servicediscovery: use haproxy1.5 image

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -151,8 +151,8 @@ __EOF__
   hyper::test::pull_image busybox
   hyper::test::check_image busybox
 
-  hyper::test::pull_image "haproxy:1.4"
-  hyper::test::check_image "haproxy" "1.4"
+  hyper::test::pull_image "haproxy:1.5"
+  hyper::test::check_image "haproxy" "1.5"
 
   ########################
   # gRPC API integration #


### PR DESCRIPTION
since commit 30b3bf772ba9fb258ef5a4c7d125eca0584ef4ff of
hyperstart, the processes of container will be killed when
container init is exited. in haproxy 1.4 image, haproxy seems
like will fork child process and exit immediately, this cause
service discovery lose effect.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>