### PR TITLE
[hyperctl / API] Add -q params to `hyperctl list` command

### DIFF
--- a/client/api/interface.go
+++ b/client/api/interface.go
@@ -18,7 +18,7 @@ type APIInterface interface {
 
 	WinResize(id, tag string, height, width int) error
 
-	List(item, pod, vm string, aux bool) (*engine.Env, error)
+	List(item, pod, vm string, aux bool, quiet bool) (*engine.Env, error)
 	GetContainerInfo(container string) (*types.ContainerInfo, error)
 	GetContainerByPod(podId string) (string, error)
 	GetExitCode(container, tag string) error

--- a/client/api/list.go
+++ b/client/api/list.go
@@ -40,11 +40,14 @@ func (cli *Client) GetContainerByPod(podId string) (string, error) {
 	return "", fmt.Errorf("Container not found")
 }
 
-func (cli *Client) List(item, pod, vm string, aux bool) (*engine.Env, error) {
+func (cli *Client) List(item, pod, vm string, aux bool, quiet bool) (*engine.Env, error) {
 	v := url.Values{}
 	v.Set("item", item)
 	if aux {
 		v.Set("auxiliary", "yes")
+	}
+	if quiet {
+		v.Set("quiet", "yes")
 	}
 	if pod != "" {
 		v.Set("pod", pod)

--- a/client/list.go
+++ b/client/list.go
@@ -76,10 +76,8 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 			if opts.Quiet {
 				fmt.Fprintf(w, "%s\n", vm)
 			} else {
-				for _, vm := range vmResponse {
-					fields := strings.Split(vm, ":")
-					fmt.Fprintf(w, "%s\t%s\n", fields[0], fields[2])
-				}
+				fields := strings.Split(vm, ":")
+				fmt.Fprintf(w, "%s\t%s\n", fields[0], fields[2])
 			}
 		}
 	}
@@ -93,10 +91,8 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 			if opts.Quiet {
 				fmt.Fprintf(w, "%s\n", p)
 			} else {
-				for _, p := range podResponse {
-					fields := strings.Split(p, ":")
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", fields[0], fields[1], fields[2], fields[3])
-				}
+				fields := strings.Split(p, ":")
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", fields[0], fields[1], fields[2], fields[3])
 			}
 		}
 	}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -166,7 +166,7 @@ func (daemon *Daemon) ListContainers(podId, vmId string, auxiliary bool) ([]*hyp
 	return results, nil
 }
 
-func (daemon *Daemon) List(item, podId, vmId string, auxiliary bool) (map[string][]string, error) {
+func (daemon *Daemon) List(item, podId, vmId string, auxiliary bool, quiet bool) (map[string][]string, error) {
 	var (
 		list                  = make(map[string][]string)
 		vmJsonResponse        = []string{}
@@ -184,7 +184,11 @@ func (daemon *Daemon) List(item, podId, vmId string, auxiliary bool) (map[string
 		}
 
 		for _, vm := range VMs {
-			vmJsonResponse = append(vmJsonResponse, vm.Id+":"+daemon.showVM(vm))
+			if quiet {
+				vmJsonResponse = append(vmJsonResponse, vm.Id)
+			} else {
+				vmJsonResponse = append(vmJsonResponse, vm.Id+":"+daemon.showVM(vm))
+			}
 		}
 
 		list["vmData"] = vmJsonResponse
@@ -197,7 +201,11 @@ func (daemon *Daemon) List(item, podId, vmId string, auxiliary bool) (map[string
 		}
 
 		for _, p := range pods {
-			podJsonResponse = append(podJsonResponse, p.Id+":"+daemon.showPod(p.PodStatus))
+			if quiet {
+				podJsonResponse = append(podJsonResponse, p.Id)
+			} else {
+				podJsonResponse = append(podJsonResponse, p.Id+":"+daemon.showPod(p.PodStatus))
+			}
 		}
 
 		list["podData"] = podJsonResponse
@@ -210,7 +218,11 @@ func (daemon *Daemon) List(item, podId, vmId string, auxiliary bool) (map[string
 		}
 
 		for _, c := range containers {
-			containerJsonResponse = append(containerJsonResponse, daemon.showContainer(c))
+			if quiet {
+				containerJsonResponse = append(containerJsonResponse, daemon.showContainerId(c))
+			} else {
+				containerJsonResponse = append(containerJsonResponse, daemon.showContainer(c))
+			}
 		}
 
 		list["cData"] = containerJsonResponse
@@ -304,4 +316,8 @@ func (daemon *Daemon) GetContainerStatus(state uint32) string {
 
 func (daemon *Daemon) showContainer(c *hypervisor.ContainerStatus) string {
 	return c.Id + ":" + c.Name + ":" + c.PodId + ":" + daemon.GetContainerStatus(c.Status)
+}
+
+func (daemon *Daemon) showContainerId(c *hypervisor.ContainerStatus) string {
+	return c.Id
 }

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -257,8 +257,8 @@ func (daemon *Daemon) CmdGetContainerInfo(name string) (interface{}, error) {
 	return daemon.GetContainerInfo(name)
 }
 
-func (daemon *Daemon) CmdList(item, podId, vmId string, auxiliary bool) (*engine.Env, error) {
-	list, err := daemon.List(item, podId, vmId, auxiliary)
+func (daemon *Daemon) CmdList(item, podId, vmId string, auxiliary bool, quiet bool) (*engine.Env, error) {
+	list, err := daemon.List(item, podId, vmId, auxiliary, quiet)
 	if err != nil {
 		return nil, err
 	}

--- a/server/router/pod/backend.go
+++ b/server/router/pod/backend.go
@@ -16,7 +16,7 @@ type Backend interface {
 	CmdStartPod(in io.ReadCloser, out io.WriteCloser, podId, vmId string, attach bool) (*engine.Env, error)
 	CmdPausePod(podId string) error
 	CmdUnpausePod(podId string) error
-	CmdList(item, podId, vmId string, auxiliary bool) (*engine.Env, error)
+	CmdList(item, podId, vmId string, auxiliary bool, quiet bool) (*engine.Env, error)
 	CmdStopPod(podId, stopVm string) (*engine.Env, error)
 	CmdKillPod(podName, container string, signal int64) (*engine.Env, error)
 	CmdCleanPod(podId string) (*engine.Env, error)

--- a/server/router/pod/pod_routes.go
+++ b/server/router/pod/pod_routes.go
@@ -48,10 +48,11 @@ func (p *podRouter) getList(ctx context.Context, w http.ResponseWriter, r *http.
 	auxiliary := httputils.BoolValue(r, "auxiliary")
 	pod := r.Form.Get("pod")
 	vm := r.Form.Get("vm")
+	quiet := httputils.BoolValue(r, "quiet")
 
-	glog.V(1).Infof("List type is %s, specified pod: [%s], specified vm: [%s], list auxiliary pod: %v", item, pod, vm, auxiliary)
+	glog.V(1).Infof("List type is %s, specified pod: [%s], specified vm: [%s], list auxiliary pod: %v, quiet mode: %v", item, pod, vm, auxiliary, quiet)
 
-	env, err := p.backend.CmdList(item, pod, vm, auxiliary)
+	env, err := p.backend.CmdList(item, pod, vm, auxiliary, quiet)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While running `docker ps` command, there is a params called `-q`, that only list container ids, without header and other information. The pure id list can be added to some other commands easily, such as `docker stop $(docker ps -aq)`.

This PR added `-q` to `hyperctl list` command to simulate the function. With this params, hyperctl list only shows id for VM / Pod / Container. Please help to review, thanks.
