### PR TITLE
hypercli: don't setup workdir for container by default

### DIFF
--- a/client/run.go
+++ b/client/run.go
@@ -29,7 +29,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) (err error) {
 		Name          string   `long:"name" value-name:"\"\"" description:"Assign a name to the container"`
 		Attach        bool     `short:"a" long:"attach" default:"false" default-mask:"-" description:"(from podfile) Attach the stdin, stdout and stderr to the container"`
 		Detach        bool     `short:"d" long:"detach" default:"false" default-mask:"-" description:"(from cmdline) Not Attach the stdin, stdout and stderr to the container"`
-		Workdir       string   `long:"workdir" default:"/" value-name:"\"\"" default-mask:"-" description:"Working directory inside the container"`
+		Workdir       string   `long:"workdir" value-name:"\"\"" default-mask:"-" description:"Working directory inside the container"`
 		Tty           bool     `short:"t" long:"tty" default:"false" default-mask:"-" description:"the run command in tty, such as bash shell"`
 		Cpu           int      `long:"cpu" default:"1" value-name:"1" default-mask:"-" description:"CPU number for the VM"`
 		Memory        int      `long:"memory" default:"128" value-name:"128" default-mask:"-" description:"Memory size (MB) for the VM"`


### PR DESCRIPTION
otherwise hyperd will ignore the workdir value got from
docker inspect image.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>