### PR TITLE
add VERSION default

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	GITCOMMIT string = "0"
-	VERSION   string
+	VERSION   string = "0.7.0"
 
 	IAMSTATIC string = "true"
 	INITSHA1  string = ""


### PR DESCRIPTION
This makes it possible to import the client from another project without running the Makefile

I'm not sure if that's the best solution, but having to run the Makefile is a major PITA when hyperd/client is a dependency. Or maybe I'm missing something since I'm just getting started with Go, but the Go creators seem to have decided that proper build systems are unnecessary.