### PR TITLE
Remove pod volume validation

### DIFF
--- a/types/validate.go
+++ b/types/validate.go
@@ -83,7 +83,7 @@ func (pod *UserPod) Validate() error {
 		}
 
 		for _, v := range container.Volumes {
-			if _, ok := vset[v.Volume]; !ok {
+			if _, ok := vset[v.Volume]; !ok && v.Detail == nil {
 				return fmt.Errorf("in container %d, volume %s does not exist in volume list.", idx, v.Volume)
 			}
 		}


### PR DESCRIPTION
Fixes: https://github.com/hyperhq/hyperd/issues/487

Since we do not set volumes in pod anymore (correct me if I'm wrong), why don't remove the validate process?

Signed-off-by: Harry Zhang <harryz@hyper.sh>