### PR TITLE
error log fix

### DIFF
--- a/utils/sync.go
+++ b/utils/sync.go
@@ -118,7 +118,7 @@ func (fs *FutureSet) Wait(timeout time.Duration) error {
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("finished with errors: %#v", errs)
+		return fmt.Errorf("finished with errors: %v", errs)
 	}
 
 	return nil


### PR DESCRIPTION
fmt %#v on error{} does not print error strings as intended:
map[string]error{"1":(*errors.errorString)(0xc82000a310), "2":(*errors.errorString)(0xc82000a330)}