### PR TITLE
support nfs volumes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/hyperhq/hyperd",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v76",
+	"GodepVersion": "v77",
 	"Packages": [
 		".",
 		"github.com/hyperhq/hyperd/cmds/protoc-gen-gogo",
@@ -1254,133 +1254,133 @@
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/api",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/driverloader",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/base",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/cache",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/direct",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/multi",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/single",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/template",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hyperstart/api/json",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hyperstart/libhyperstart",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/libvirt",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/network",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/network/ipallocator",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/network/iptables",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/network/portmapper",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/qemu",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/types",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/vbox",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/xen",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/lib/govbox",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/lib/telnet",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/lib/term",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/lib/utils",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/template",
-			"Comment": "v0.7.0-74-ga8930a9",
-			"Rev": "a8930a94146f58a8caa341c903a577e30f8f719d"
+			"Comment": "v0.7.0-82-ge6eebdc",
+			"Rev": "e6eebdc6663c73381d855581ee11028712000e3c"
 		},
 		{
 			"ImportPath": "github.com/imdario/mergo",

--- a/examples/nfs-volume.pod
+++ b/examples/nfs-volume.pod
@@ -1,0 +1,20 @@
+{
+  "resource": {
+    "vcpu": 1,
+    "memory": 1024
+  },
+  "containers": [{
+      "image": "ubuntu",
+      "volumes": [{
+	"volume": "sharevolume",
+	"path": "/export",
+	"readOnly": false
+      }]
+  }],
+  "volumes": [{
+    "name": "sharevolume",
+    "source": "192.168.80.72:/export",
+    "format": "nas",
+    "fstype": "nfs"
+  }]
+}

--- a/hack/pods/nfs-client.pod
+++ b/hack/pods/nfs-client.pod
@@ -1,0 +1,21 @@
+{
+  "resource": {
+    "vcpu": 1,
+    "memory": 256
+  },
+  "containers": [{
+      "image": "busybox",
+      "command": ["/bin/sh", "-c", "touch /export/foo"],
+      "volumes": [{
+	"volume": "sharevolume",
+	"path": "/export",
+	"readOnly": false
+      }]
+  }],
+  "volumes": [{
+    "name": "sharevolume",
+    "source": "NFSSERVER:/export",
+    "format": "nas",
+    "fstype": "nfs"
+  }]
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -176,6 +176,7 @@ __EOF__
   hyper::test::map_file
   hyper::test::with_volume
   hyper::test::service
+  hyper::test::nfs_volume
 
   stop_hyperd
 }

--- a/types/validate.go
+++ b/types/validate.go
@@ -19,6 +19,7 @@ func (pod *UserPod) Validate() error {
 		"vdi":   true,
 		"vfs":   true,
 		"rbd":   true,
+		"nas":   true,
 	}
 
 	hostnameLen := len(pod.Hostname)

--- a/vendor/github.com/hyperhq/runv/api/helpers.go
+++ b/vendor/github.com/hyperhq/runv/api/helpers.go
@@ -11,6 +11,10 @@ func (v *VolumeDescription) IsDir() bool {
 	return v.Format == "vfs"
 }
 
+func (v *VolumeDescription) IsNas() bool {
+	return v.Format == "nas"
+}
+
 func SandboxInfoFromOCF(s *specs.Spec) *SandboxConfig {
 	return &SandboxConfig{
 		Hostname: s.Hostname,

--- a/vendor/github.com/hyperhq/runv/hypervisor/hypervisor.go
+++ b/vendor/github.com/hyperhq/runv/hypervisor/hypervisor.go
@@ -23,6 +23,12 @@ func (ctx *VmContext) loop() {
 		glog.V(1).Infof("vm %s: main event loop got message %d(%s)", ctx.Id, ev.Event(), EventString(ev.Event()))
 		ctx.handler(ctx, ev)
 	}
+
+	// Unless the ctx.Hub channel is drained, processes sending operations can
+	// be left hanging waiting for a response. Since the handler is already
+	// gone, we return a fail to all these requests.
+
+	glog.V(1).Infof("vm %s: main event loop exiting", ctx.Id)
 }
 
 func (ctx *VmContext) handlePAEs() {

--- a/vendor/github.com/hyperhq/runv/hypervisor/qemu/qmp_handler.go
+++ b/vendor/github.com/hyperhq/runv/hypervisor/qemu/qmp_handler.go
@@ -150,6 +150,8 @@ func qmpReceiver(qmp chan QmpInteraction, wait chan int, decoder *json.Decoder) 
 
 		if msg.MessageType() == QMP_EVENT && msg.(*QmpEvent).Type == QMP_EVENT_SHUTDOWN {
 			glog.V(0).Info("Shutdown, quit QMP receiver")
+			/* After shutdown, send wait notification to close qmp channel */
+			close(wait)
 			return
 		}
 	}


### PR DESCRIPTION
The PR imports runv nfs support (https://github.com/hyperhq/runv/pull/417) and adds nfs volumes support to hyperd, with a podfile example listed.

podfile example:
```
{
  "resource": {
    "vcpu": 1,
    "memory": 1024
  },
  "containers": [{
      "image": "bergwolf/ubuntu-fio",
      "volumes": [{
        "volume": "sharevolume",
        "path": "/export",
        "readOnly": false
      }]
  }],
  "volumes": [{
    "name": "sharevolume",
    "source": "192.168.80.72:/home/bergwolf",
    "format": "nas",
    "fstype": "nfs"
  }]
}
```

```
[hypervsock@~]$sudo hyperctl run -d -p ubuntu.pod
POD id is pod-VVnZwkkoZp
Time to run a POD is 7733 ms
[hypervsock@~]$sudo hyperctl exec -t pod-VVnZwkkoZp bash
root@pod-VVnZwkkoZp:/# df
Filesystem                   1K-blocks      Used Available Use% Mounted on
/dev/sda                     104805376    298180 104507196   1% /
devtmpfs                         23808         0     23808   0% /dev
tmpfs                            26940         0     26940   0% /dev/shm
rootfs                           23808     16044      7764  68% /lib/modules/4.4.28-hyper
192.168.80.72:/home/bergwolf 410056704 108126208 301930496  27% /export
```