### PR TITLE
Migrate lagecy persistent data to current layout before restore daemon

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -41,6 +41,14 @@ type Daemon struct {
 }
 
 func (daemon *Daemon) Restore() error {
+	//try to migrate lagecy data first
+	err := pod.MigrateLagecyPersistentData(daemon.db, func() *pod.PodFactory {
+		return pod.NewPodFactory(daemon.Factory, daemon.PodList, daemon.db, daemon.Storage, daemon.Daemon, daemon.DefaultLog)
+	})
+	if err != nil {
+		return err
+	}
+
 	if daemon.GetPodNum() == 0 {
 		return nil
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -289,7 +289,7 @@ func (daemon *Daemon) WritePodAndContainers(podId string) error {
 		containers = append(containers, c)
 	}
 
-	return daemon.db.UpdateP2C(podId, containers)
+	return daemon.db.LagecyUpdateP2C(podId, containers)
 }
 
 func (daemon *Daemon) GetVmByPodId(podId string) (string, error) {

--- a/daemon/daemondb/daemondb.go
+++ b/daemon/daemondb/daemondb.go
@@ -27,38 +27,38 @@ func NewDaemonDB(db_file string) (*DaemonDB, error) {
 }
 
 // Composition Process
-func (d *DaemonDB) DeleteVMByPod(id string) error {
-	v, err := d.GetP2V(id)
+func (d *DaemonDB) LagecyDeleteVMByPod(id string) error {
+	v, err := d.LagecyGetP2V(id)
 	if err != nil {
 		return err
 	}
-	d.DeleteP2V(id)
-	if err := d.DeleteVM(v); err != nil {
+	d.LagecyDeleteP2V(id)
+	if err := d.LagecyDeleteVM(v); err != nil {
 		return err
 	}
 	return nil
 }
 
 // Pods podId and args
-func (d *DaemonDB) GetPod(id string) ([]byte, error) {
+func (d *DaemonDB) LagecyGetPod(id string) ([]byte, error) {
 	return d.Get(keyPod(id))
 }
 
-func (d *DaemonDB) UpdatePod(id string, data []byte) error {
+func (d *DaemonDB) LagecyUpdatePod(id string, data []byte) error {
 	return d.Update(keyPod(id), data)
 }
 
-func (d *DaemonDB) DeletePod(id string) error {
+func (d *DaemonDB) LagecyDeletePod(id string) error {
 	return d.db.Delete(keyPod(id), nil)
 }
 
-func (d *DaemonDB) ListPod() ([][]byte, error) {
+func (d *DaemonDB) LagecyListPod() ([][]byte, error) {
 	return d.PrefixListKey(prefixPod(), func(key []byte) bool {
 		return !strings.HasPrefix(string(key), POD_CONTAINER_PREFIX)
 	})
 }
 
-func (d *DaemonDB) GetAllPods() chan *KVPair {
+func (d *DaemonDB) LagecyGetAllPods() chan *KVPair {
 	return d.PrefixList2Chan(prefixPod(), func(key []byte) bool {
 		return !strings.HasPrefix(string(key), POD_CONTAINER_PREFIX)
 	})
@@ -86,7 +86,7 @@ func (d *DaemonDB) DeletePodVolumes(podId string) error {
 }
 
 // POD to Containers (string to string list)
-func (d *DaemonDB) GetP2C(id string) ([]string, error) {
+func (d *DaemonDB) LagecyGetP2C(id string) ([]string, error) {
 	glog.V(3).Info("try get container list for pod ", id)
 	cl, err := d.Get(keyP2C(id))
 	if err != nil || len(cl) == 0 {
@@ -95,34 +95,34 @@ func (d *DaemonDB) GetP2C(id string) ([]string, error) {
 	return strings.Split(string(cl), ":"), nil
 }
 
-func (d *DaemonDB) UpdateP2C(id string, containers []string) error {
+func (d *DaemonDB) LagecyUpdateP2C(id string, containers []string) error {
 	glog.V(3).Infof("try set container list for pod %s: %v", id, containers)
 	return d.Update(keyP2C(id), []byte(strings.Join(containers, ":")))
 }
 
-func (d *DaemonDB) DeleteP2C(id string) error {
+func (d *DaemonDB) LagecyDeleteP2C(id string) error {
 	return d.db.Delete(keyP2C(id), nil)
 }
 
 // POD to VM (string to string)
-func (d *DaemonDB) GetP2V(id string) (string, error) {
+func (d *DaemonDB) LagecyGetP2V(id string) (string, error) {
 	return d.GetString(keyP2V(id))
 }
 
-func (d *DaemonDB) UpdateP2V(id, vm string) error {
+func (d *DaemonDB) LagecyUpdateP2V(id, vm string) error {
 	return d.Update(keyP2V(id), []byte(vm))
 }
 
-func (d *DaemonDB) DeleteP2V(id string) error {
+func (d *DaemonDB) LagecyDeleteP2V(id string) error {
 	return d.db.Delete(keyP2V(id), nil)
 }
 
-func (d *DaemonDB) DeleteAllP2V() error {
+func (d *DaemonDB) LagecyDeleteAllP2V() error {
 	return d.PrefixDelete(prefixP2V())
 }
 
 // VM DATA (string to data)
-func (d *DaemonDB) GetVM(id string) ([]byte, error) {
+func (d *DaemonDB) LagecyGetVM(id string) ([]byte, error) {
 	data, err := d.db.Get(keyVMData(id), nil)
 	if err != nil {
 		return []byte(""), err
@@ -130,11 +130,11 @@ func (d *DaemonDB) GetVM(id string) ([]byte, error) {
 	return data, nil
 }
 
-func (d *DaemonDB) UpdateVM(id string, data []byte) error {
+func (d *DaemonDB) LagecyUpdateVM(id string, data []byte) error {
 	return d.Update(keyVMData(id), data)
 }
 
-func (d *DaemonDB) DeleteVM(id string) error {
+func (d *DaemonDB) LagecyDeleteVM(id string) error {
 	return d.db.Delete(keyVMData(id), nil)
 }
 

--- a/daemon/pod/migration.go
+++ b/daemon/pod/migration.go
@@ -1,0 +1,209 @@
+package pod
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/pkg/version"
+	dockertypes "github.com/docker/engine-api/types"
+	"github.com/hyperhq/hypercontainer-utils/hlog"
+	"github.com/hyperhq/hyperd/daemon/daemondb"
+	"github.com/hyperhq/hyperd/types"
+	apitypes "github.com/hyperhq/hyperd/types"
+)
+
+// MigrateLagecyData migrate lagecy persistence data to current layout.
+func MigrateLagecyPersistentData(db *daemondb.DaemonDB, podFactory func() *PodFactory) (err error) {
+	num := 0
+	count := 0
+	defer func() {
+		logInfo := fmt.Sprintf("Migrate lagecy persistent pod data, found: %d, migrated: %d", num, count)
+		if err == nil {
+			hlog.Log(INFO, logInfo)
+		} else {
+			hlog.Log(ERROR, "%s, but failed with %v", logInfo, err)
+		}
+	}()
+	list, err := db.LagecyListPod()
+	if err != nil {
+		return err
+	}
+	num = len(list)
+	if num == 0 {
+		return nil
+	}
+	ch := db.LagecyGetAllPods()
+	if ch == nil {
+		err = fmt.Errorf("cannot list pods in daemondb")
+		return err
+	}
+	for {
+		item, ok := <-ch
+		if !ok {
+			break
+		}
+		if item == nil {
+			err = fmt.Errorf("error during get pods from daemondb")
+			return err
+		}
+
+		podID := string(item.K[4:])
+
+		hlog.Log(TRACE, "try to migrate lagecy pod %s from daemondb", podID)
+
+		var podSpec apitypes.UserPod
+		if err = json.Unmarshal(item.V, &podSpec); err != nil {
+			return err
+		}
+
+		factory := podFactory()
+
+		// fill in corresponding container id in pod spec
+		if err = setupContanerID(factory, podID, &podSpec); err != nil {
+			return err
+		}
+		// convert some lagecy volume field to current format
+		if err = setupVolumes(factory.db, podID, item.V, &podSpec); err != nil {
+			return err
+		}
+
+		if err = persistLagecyPod(factory, &podSpec); err != nil {
+			return err
+		}
+
+		var vmID string
+		if vmID, err = db.LagecyGetP2V(podID); err != nil {
+			hlog.Log(DEBUG, "no existing VM for pod %s: %v", podID, err)
+		} else {
+			var vmData []byte
+			if vmData, err = db.LagecyGetVM(vmID); err != nil {
+				return err
+			}
+			// save sandbox data in current layout
+			sandboxInfo := types.SandboxPersistInfo{
+				Id:          vmID,
+				PersistInfo: vmData,
+			}
+			err = saveMessage(db, fmt.Sprintf(SB_KEY_FMT, podID), &sandboxInfo, nil, "sandbox info")
+			if err != nil {
+				return err
+			}
+		}
+
+		errs := purgeLagecyPersistPod(db, podID)
+		if len(errs) != 0 {
+			hlog.Log(DEBUG, "%v", errs)
+		}
+		count++
+	}
+	return nil
+}
+
+func setupVolumes(db *daemondb.DaemonDB, podID string, persist []byte, podSpec *apitypes.UserPod) (err error) {
+	var (
+		vinfo       []byte
+		specMap     map[string]interface{}
+		raw_volumes []interface{}
+	)
+	if err = json.Unmarshal(persist, &specMap); err != nil {
+		return err
+	}
+	raw_raw_volumes, success := specMap["volumes"]
+	if success {
+		raw_volumes, success = raw_raw_volumes.([]interface{})
+	}
+	for i, vol := range podSpec.Volumes {
+		// copy lagecy field Volumes[i].Driver to Format
+		if success {
+			raw_vol, ok := raw_volumes[i].(map[string]interface{})
+			if ok {
+				raw_driver, ok := raw_vol["driver"]
+				if ok {
+					driver, ok := raw_driver.(string)
+					if ok {
+						vol.Format = driver
+					}
+				}
+			}
+		}
+		// replace podID with spec.Id in hostvolume path
+		vol.Source = strings.Replace(vol.Source, podID, podSpec.Id, 1)
+		// replace podId with spec.Id in volume persist key
+		vinfo, err = db.GetPodVolume(podID, vol.Name)
+		if err == nil {
+			if err = db.UpdatePodVolume(podSpec.Id, vol.Name, vinfo); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func purgeLagecyPersistPod(db *daemondb.DaemonDB, podID string) []error {
+	var errs []error
+	err := db.LagecyDeleteVMByPod(podID)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("remove vm: %v", err))
+	}
+	if err = db.LagecyDeletePod(podID); err != nil {
+		errs = append(errs, fmt.Errorf("remove pod: %v", err))
+	}
+	if err = db.LagecyDeleteP2C(podID); err != nil {
+		errs = append(errs, fmt.Errorf("remove pod container: %v", err))
+	}
+	if err = db.DeletePodVolumes(podID); err != nil {
+		errs = append(errs, fmt.Errorf("remove pod volumes: %v", err))
+	}
+	return errs
+}
+
+func setupContanerID(factory *PodFactory, podID string, spec *apitypes.UserPod) error {
+	cIDs, err := factory.db.LagecyGetP2C(podID)
+	if err != nil {
+		return err
+	}
+	for _, cID := range cIDs {
+		r, err := factory.engine.ContainerInspect(cID, false, version.Version("1.21"))
+		if err == nil {
+			rsp, ok := r.(*dockertypes.ContainerJSON)
+			if !ok {
+				hlog.Log(ERROR, "fail to got loaded container info: %v", r)
+				return nil
+			}
+			n := strings.TrimLeft(rsp.Name, "/")
+			found := false
+			for _, ctr := range spec.Containers {
+				if ctr.Name == n {
+					ctr.Id = cID
+					found = true
+					break
+				}
+			}
+			if !found {
+				err = fmt.Errorf("cannot find a match container with ID(%s)", cID)
+				hlog.Log(ERROR, err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func persistLagecyPod(factory *PodFactory, spec *apitypes.UserPod) error {
+	p, err := newXPod(factory, spec)
+	if err != nil {
+		return err
+	}
+	if err = p.initResources(spec, false); err != nil {
+		return err
+	}
+	if err = p.prepareResources(); err != nil {
+		return err
+	}
+
+	if err = p.savePod(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
field `driver` in UserVolume have been renamed to `format`, I added it back for compatibility.
Should I just revert 'format' back to 'driver'?

I've test it in aufs/devicemapper + default/qemu combination, works fine. I've some issue running libvirt driver in my local environment, but it should be fine, since this is only concerned with hyperd part data.
Sandbox part will be fixed and tested in hyperhq/runv#441

/cc @laijs 