### PR TITLE
Add ExecVM API

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/hyperhq/hyperd",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		".",
 		"github.com/hyperhq/hyperd/cmds/protoc-gen-gogo",
@@ -1254,133 +1254,133 @@
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/api",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/driverloader",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/base",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/cache",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/direct",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/multi",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/single",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/factory/template",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hyperstart/api/json",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hyperstart/libhyperstart",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/libvirt",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/network",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/network/ipallocator",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/network/iptables",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/network/portmapper",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/qemu",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/types",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/vbox",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/hypervisor/xen",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/lib/govbox",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/lib/telnet",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/lib/term",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/lib/utils",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/hyperhq/runv/template",
-			"Comment": "v0.7.0-127-gfa0a5c2",
-			"Rev": "fa0a5c2ece83147e88f929aec0c01925fbec76d6"
+			"Comment": "v0.7.0-130-gb7cc550",
+			"Rev": "b7cc550f26f74bebdf36426677d5a99013f9959c"
 		},
 		{
 			"ImportPath": "github.com/imdario/mergo",

--- a/client/api/exec.go
+++ b/client/api/exec.go
@@ -80,3 +80,47 @@ func (cli *Client) StartExec(containerId, execId string, tty bool, stdin io.Read
 
 	return nil
 }
+
+func (cli *Client) ExecVM(podID string, command []byte, stdin io.ReadCloser, stdout, stderr io.Writer) error {
+	v := url.Values{}
+	v.Set("pod", podID)
+	v.Set("command", string(command))
+
+	var (
+		hijacked = make(chan io.Closer)
+		errCh    chan error
+	)
+	// Block the return until the chan gets closed
+	defer func() {
+		//fmt.Printf("End of CmdExec(), Waiting for hijack to finish.\n")
+		if _, ok := <-hijacked; ok {
+			fmt.Printf("Hijack did not finish (chan still open)\n")
+		}
+	}()
+
+	errCh = promise.Go(func() error {
+		return cli.hijack("POST", "/execvm?"+v.Encode(), true, stdin, stdout, stdout, hijacked, nil, "")
+	})
+
+	// Acknowledge the hijack before starting
+	select {
+	case closer := <-hijacked:
+		// Make sure that hijack gets closed when returning. (result
+		// in closing hijack chan and freeing server's goroutines.
+		if closer != nil {
+			defer closer.Close()
+		}
+	case err := <-errCh:
+		if err != nil {
+			fmt.Printf("Error hijack: %s", err.Error())
+			return err
+		}
+	}
+
+	if err := <-errCh; err != nil {
+		fmt.Printf("Error hijack: %s", err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/client/api/hijack.go
+++ b/client/api/hijack.go
@@ -120,10 +120,6 @@ func (cli *Client) hijack(method, path string, setRawTerminal bool, in io.ReadCl
 		receiveStdout chan error
 	)
 
-	if in != nil && setRawTerminal {
-		// fmt.Printf("In the Raw Terminal!!!\n")
-	}
-
 	if stdout != nil || stderr != nil {
 		receiveStdout = promise.Go(func() (err error) {
 			defer func() {

--- a/client/api/interface.go
+++ b/client/api/interface.go
@@ -15,6 +15,7 @@ type APIInterface interface {
 	Attach(container string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error
 	CreateExec(containerId string, command []byte, tty bool) (string, error)
 	StartExec(containerId, execId string, tty bool, stdin io.ReadCloser, stdout, stderr io.Writer) error
+	ExecVM(podID string, command []byte, stdin io.ReadCloser, stdout, stderr io.Writer) error
 
 	WinResize(id, tag string, height, width int) error
 

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -58,3 +58,15 @@ func (daemon *Daemon) KillExec(containerId string, execId string, signal int64) 
 	glog.V(1).Infof("Kill Exec for container %s", containerId)
 	return p.KillExec(execId, signal)
 }
+
+func (daemon *Daemon) ExecVM(podID, cmd string, stdin io.ReadCloser, stdout, stderr io.WriteCloser) (int, error) {
+	glog.V(3).Infof("Starting ExecVM for pod %s", podID)
+	p, ok := daemon.PodList.Get(podID)
+	if !ok {
+		err := fmt.Errorf("cannot find pod %s", podID)
+		glog.Error(err)
+		return -1, err
+	}
+
+	return p.ExecVM(cmd, stdin, stdout, stderr)
+}

--- a/daemon/pod/exec.go
+++ b/daemon/pod/exec.go
@@ -204,3 +204,11 @@ func (p *XPod) CleanupExecs() {
 	p.execs = make(map[string]*Exec)
 	p.statusLock.Unlock()
 }
+
+func (p *XPod) ExecVM(cmd string, stdin io.ReadCloser, stdout, stderr io.WriteCloser) (int, error) {
+	return p.sandbox.HyperstartExec(cmd, &hypervisor.TtyIO{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+}

--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -145,3 +145,13 @@ hyper::test::integration() {
   export GOPATH=${HYPER_ROOT}/Godeps/_workspace:$GOPATH
   go test github.com/hyperhq/hyperd/integration -check.vv -v
 }
+
+hyper::test::execvm() {
+  echo "Pod execvm echo test"
+  id=$(sudo hyperctl run -d busybox /bin/sh | sed -ne "s/POD id is \(.*\)/\1/p")
+  echo "test pod ID is $id"
+  res=$(sudo hyperctl exec -m $id /sbin/busybox sh -c "echo aaa")
+  echo "should return aaa, actual: $res"
+  test $res == aaa
+  sudo hyperctl rm $id
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -177,6 +177,7 @@ __EOF__
   hyper::test::with_volume
   hyper::test::service
   hyper::test::nfs_volume
+  hyper::test::execvm
 
   stop_hyperd
 }

--- a/server/router/container/backend.go
+++ b/server/router/container/backend.go
@@ -23,4 +23,5 @@ type Backend interface {
 	CmdTtyResize(podId, tag string, h, w int) error
 	CreateExec(id, cmd string, terminal bool) (string, error)
 	StartExec(stdin io.ReadCloser, stdout io.WriteCloser, containerId, execId string) error
+	ExecVM(podID, cmd string, stdin io.ReadCloser, stdout, stderr io.WriteCloser) (int, error)
 }

--- a/server/router/container/container.go
+++ b/server/router/container/container.go
@@ -44,6 +44,7 @@ func (r *containerRouter) initRoutes() {
 		local.NewPostRoute("/exec/start", r.postContainerExecStart),
 		local.NewPostRoute("/attach", r.postContainerAttach),
 		local.NewPostRoute("/tty/resize", r.postTtyResize),
+		local.NewPostRoute("/execvm", r.postExecVM),
 		// PUT
 		// DELETE
 	}

--- a/types/types.proto
+++ b/types/types.proto
@@ -565,6 +565,17 @@ message ExecStartResponse{
     bytes stdout = 1;
 }
 
+message ExecVMRequest{
+    string podID            = 1;
+    repeated string command = 2;
+    bytes  stdin            = 3;
+}
+
+message ExecVMResponse{
+    bytes stdout   = 1;
+    int32 exitCode = 2;
+}
+
 message ExecSignalRequest{
     string containerID      = 1;
     string execID           = 2;
@@ -789,6 +800,8 @@ service PublicAPI {
     rpc PodPause(PodPauseRequest) returns (PodPauseResponse) {}
     // PodUnpause unpauses a pod
     rpc PodUnpause(PodUnpauseRequest) returns (PodUnpauseResponse) {}
+    // ExecVM executes a command outside of any containers.
+    rpc ExecVM(stream ExecVMRequest) returns (stream ExecVMResponse) {}
 
     // ContainerList gets a list of containers
     rpc ContainerList(ContainerListRequest) returns (ContainerListResponse) {}


### PR DESCRIPTION
This PR adds ExecVM API and its client to hyperd.

Depends on https://github.com/hyperhq/runv/pull/443.

```sh
# curl --unix-socket /var/run/hyper.sock -X POST "http://localhost/execvm?pod=nginx-9296454126&command=\[\"/sbin/busybox\",\"ls\",\"/sbin\"\]"
busybox
depmod
iptables
iptables-restore
iptables-save
ipvsadm
modprobe
mount.nfs4

# ./hyperctl exec -m nginx-9296454126 /sbin/busybox ls /sbin
busybox
depmod
iptables
iptables-restore
iptables-save
ipvsadm
modprobe
mount.nfs4
```