### PR TITLE
Remove conflict ghost container when create container in docker engine

### DIFF
--- a/daemon/pod/container.go
+++ b/daemon/pod/container.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -26,8 +27,11 @@ import (
 	"github.com/hyperhq/runv/lib/term"
 )
 
-var epocZero = time.Time{}
-var DetachKeys = "ctrl-p,ctrl-q"
+var (
+	epocZero   = time.Time{}
+	DetachKeys = "ctrl-p,ctrl-q"
+	conflictRE = regexp.MustCompile(`Conflict. (?:.)+ is already in use by container ([0-9a-z]+)`)
+)
 
 type ContainerState int32
 
@@ -487,7 +491,21 @@ func (c *Container) createByEngine() (*dockertypes.ContainerJSON, error) {
 	})
 
 	if err != nil {
-		return nil, err
+		// TODO fix all the conflict reason and remove this.
+		matches := conflictRE.FindStringSubmatch(err.Error())
+		if len(matches) != 2 {
+			return nil, err
+		}
+		id := matches[1]
+		c.Log(WARNING, "Find conflict ghost container %s with name %s, remove it", id, c.spec.Name)
+		c.p.factory.engine.ContainerRm(id, &dockertypes.ContainerRmConfig{})
+		ccs, err = c.p.factory.engine.ContainerCreate(dockertypes.ContainerCreateConfig{
+			Name:   c.spec.Name,
+			Config: config,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	c.Log(INFO, "create container %s (w/: %s)", ccs.ID, ccs.Warnings)


### PR DESCRIPTION
Currently, we have both hyperd and docker engine own the container name and id registry,
I think we should relay on hyperd, since container only exist in docker engine can't be reached by hyperd.
This is a quick fix if we create container conflict with ghost container in docker engine. No matter they are left behind by:
1. not proper clean up when failed in create pod and container
2. not proper clean up when failed in restore pod and container
3. not proper user behavior (such as remove `lib` dir and leave `containers`)

Signed-off-by: Crazykev <crazykev@zju.edu.cn>