### PR TITLE
parse docker config user field properly

### DIFF
--- a/daemon/pod/container.go
+++ b/daemon/pod/container.go
@@ -569,8 +569,19 @@ func (c *Container) describeContainer(cjson *dockertypes.ContainerJSON) (*runv.C
 	}
 
 	if cjson.Config.User != "" {
-		cdesc.UGI = &runv.UserGroupInfo{
-			User: cjson.Config.User,
+		users := strings.Split(cjson.Config.User, ":")
+		if len(users) > 2 {
+			return nil, fmt.Errorf("container %s invalid user group config: %s", cjson.Name, cjson.Config.User)
+		}
+		if len(users) == 2 {
+			cdesc.UGI = &runv.UserGroupInfo{
+				User:  users[0],
+				Group: users[1],
+			}
+		} else {
+			cdesc.UGI = &runv.UserGroupInfo{
+				User: cjson.Config.User,
+			}
 		}
 	}
 


### PR DESCRIPTION
Docker config user field supports:
[ user | user:group | uid | uid:gid | user:gid | uid:group ]

We need to translate it into runv spec.

```
[hypervsock@hyperhq]$sudo hyperctl run -d gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
POD id is k8s-dns-sidecar-amd64-1.14.1-9540546015
Time to run a POD is 4702 ms
[hypervsock@hyperhq]$sudo hyperctl list
POD ID                                    POD Name                                  VM name             Status
k8s-dns-sidecar-amd64-1.14.1-9540546015   k8s-dns-sidecar-amd64-1.14.1-9540546015   vm-FToockWJoz       running
[hypervsock@hyperhq]$sudo hyperctl exec k8s-dns-sidecar-amd64-1.14.1-9540546015 ps
PID   USER     TIME   COMMAND
    1 root       0:00 /init
    3 nobody     0:00 /sidecar
    7 root       0:00 ps
```

Fixes: https://github.com/hyperhq/hyperd/issues/544