### PR TITLE
respect spec user config

### DIFF
--- a/daemon/pod/container.go
+++ b/daemon/pod/container.go
@@ -568,7 +568,13 @@ func (c *Container) describeContainer(cjson *dockertypes.ContainerJSON) (*runv.C
 		cdesc.StopSignal = "TERM"
 	}
 
-	if cjson.Config.User != "" {
+	if c.spec.User != nil && c.spec.User.Name != "" {
+		cdesc.UGI = &runv.UserGroupInfo{
+			User:             c.spec.User.Name,
+			Group:            c.spec.User.Group,
+			AdditionalGroups: c.spec.User.AdditionalGroups,
+		}
+	} else if cjson.Config.User != "" {
 		users := strings.Split(cjson.Config.User, ":")
 		if len(users) > 2 {
 			return nil, fmt.Errorf("container %s invalid user group config: %s", cjson.Name, cjson.Config.User)

--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -170,3 +170,31 @@ hyper::test::remove_container_with_volume() {
   echo "check result should be 0, got: $res"
   test $res -eq 0
 }
+
+hyper::test::imageuser() {
+  echo "Pod image user config test"
+  # irssi image has "User": "user"
+  id=$(sudo hyperctl run -d --env="TERM=xterm" irssi:1 | sed -ne "s/POD id is \(.*\)/\1/p")
+  res=$(sudo hyperctl exec $id ps aux | grep user > /dev/null 2>&1; echo $?)
+  sudo hyperctl rm $id
+  test $res -eq 0
+}
+
+hyper::test::imageusergroup() {
+  echo "Pod image user group config test"
+  # k8s-dns-sidecar-amd64:1.14.1 image has "User": "nobody" and "Group": "nobody"
+  id=$(sudo hyperctl run -d gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1 | sed -ne "s/POD id is \(.*\)/\1/p")
+  res=$(sudo hyperctl exec $id ps aux | grep nobody > /dev/null 2>&1; echo $?)
+  sudo hyperctl rm $id
+  test $res -eq 0
+}
+
+hyper::test::specuseroverride() {
+  echo "Pod spec user override test"
+  # irssi image has "User": "user"
+  # user-override.pod overrides it with "User": "nobody"
+  id=$(sudo hyperctl run -p ${HYPER_ROOT}/hack/pods/user-override.pod | sed -ne "s/POD id is \(.*\)/\1/p")
+  res=$(sudo hyperctl exec $id ps aux | grep nobody > /dev/null 2>&1; echo $?)
+  sudo hyperctl rm $id
+  test $res -eq 0
+}

--- a/hack/pods/user-override.pod
+++ b/hack/pods/user-override.pod
@@ -1,0 +1,9 @@
+{
+	"containers" : [{
+	    "image": "irssi:1",
+	    "user": {
+		"name": "nobody"
+	    },
+	    "command": ["sh"]
+	}]
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -179,6 +179,9 @@ __EOF__
   hyper::test::nfs_volume
   hyper::test::execvm
   hyper::test::remove_container_with_volume
+  hyper::test::imageuser
+  hyper::test::imageusergroup
+  hyper::test::specuseroverride
 
   stop_hyperd
 }


### PR DESCRIPTION
We should respect spec user/group config and override image user/group config if spec user config is present.

Fixes https://github.com/hyperhq/hyperd/issues/548