### PR TITLE
[grpc]: fix possible leak of vm

### DIFF
--- a/hyperd.go
+++ b/hyperd.go
@@ -170,7 +170,7 @@ func mainDaemon(opt *Options) {
 		go func() {
 			err := rpcServer.Serve(c.GRPCHost)
 			if err != nil {
-				glog.Fatalf("Hyper serve RPC error: %v", err)
+				glog.Errorf("Hyper serve RPC error: %v", err)
 			}
 		}()
 	}

--- a/serverrpc/server.go
+++ b/serverrpc/server.go
@@ -34,7 +34,7 @@ func (s *ServerRPC) Serve(addr string) error {
 	glog.V(1).Infof("Start gRPC server at %s", addr)
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
-		glog.Fatalf("Failed to listen %s: %v", addr, err)
+		glog.Errorf("Failed to listen %s: %v", addr, err)
 		return err
 	}
 


### PR DESCRIPTION
when hyperd exiting, the grpc server is closed and
logging error message with glog.Fatalf api, this api
will call os.Exit(255) causing hyperd exit and has no
chance to destroy vms or do other operations.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>