### PR TITLE
fix break out of for-select

### DIFF
--- a/daemon/pod/decommission.go
+++ b/daemon/pod/decommission.go
@@ -468,7 +468,7 @@ func (p *XPod) stopContainers(cList []string, graceful int) error {
 						return err
 					}
 					p.Log(DEBUG, "container %s stopped (%v)", ex.Id, ex.Code)
-					break
+					return nil
 				case <-toc:
 					if forceKill {
 						return fmt.Errorf("timeout for killing container %s", c.Id())


### PR DESCRIPTION
introduced from #559, `select` also consume a `break`, we need `return` here.
/cc @feiskyer related with test failure in https://github.com/kubernetes/frakti/pull/113

Signed-off-by: Crazykev <crazykev@zju.edu.cn>