### PR TITLE
umount root volume only if pod is running

### DIFF
--- a/daemon/pod/decommission.go
+++ b/daemon/pod/decommission.go
@@ -263,11 +263,11 @@ func (p *XPod) RemoveContainer(id string) error {
 				removedVols = append(removedVols, cv.Name)
 			}
 		}
-	}
-	err = c.umountRootVol()
-	if err != nil {
-		c.Log(ERROR, "failed to umount root volume")
-		return err
+		err = c.umountRootVol()
+		if err != nil {
+			c.Log(ERROR, "failed to umount root volume")
+			return err
+		}
 	}
 	err = p.factory.engine.ContainerRm(id, &dockertypes.ContainerRmConfig{})
 	if err != nil {


### PR DESCRIPTION
Fix another bug found in test  `ContainerRemove failed: not a directory` , ref: #540 
could be reproduced when using fs type storage driver and doing "RunPod->StopPod->RmContainer"

Signed-off-by: Crazykev <crazykev@zju.edu.cn>