### PR TITLE
Do not close all streams right after container stopped

### DIFF
--- a/daemon/pod/container.go
+++ b/daemon/pod/container.go
@@ -1048,28 +1048,40 @@ func (c *Container) waitFinish(timeout int) {
 	result := c.p.sandbox.WaitProcess(true, []string{c.Id()}, timeout)
 	if result == nil {
 		c.Log(INFO, "wait container failed")
-		c.streams.CloseStreams()
 		firstStop = c.status.UnexpectedStopped()
 	} else {
 		r, ok := <-result
 		if !ok {
 			if timeout < 0 {
 				c.Log(INFO, "container unexpected failed, chan broken")
-				c.streams.CloseStreams()
 				firstStop = c.status.UnexpectedStopped()
 			}
 		} else {
 			c.Log(INFO, "container exited with code %v (at %v)", r.Code, r.FinishedAt)
-			c.streams.CloseStreams()
 			firstStop = c.status.Stopped(r.FinishedAt, r.Code)
 		}
 	}
 
 	if firstStop {
 		c.Log(INFO, "clean up container")
-		if c.logger.Driver != nil {
-			c.logger.Driver.Close()
-		}
+
+		//reset streams and loggers, in case restart may use them.
+		oldStreams := c.streams
+		oldLogger := c.logger.Driver
+		c.streams = NewStreamConfig()
+		c.logger.Driver = nil
+
+		//the streams should have been closed as the process terminated and hup the streams,
+		//however, we reclaim them in case they are leaved alone by some reason
+		time.AfterFunc(3*time.Second, func() {
+			if err := oldStreams.CloseStreams(); err != nil {
+				c.Log(WARNING, "failed to clean stopped streams of container: %v", err)
+				err = nil
+			}
+			if oldLogger != nil {
+				oldLogger.Close()
+			}
+		})
 	}
 }
 
@@ -1315,14 +1327,6 @@ func (c *Container) AttachStreams(streamConfig *StreamConfig, openStdin, stdinOn
 		}
 		if stdinOnce && !tty {
 			cStdin.Close()
-		} else {
-			// No matter what, when stdin is closed (io.Copy unblock), close stdout and stderr
-			if cStdout != nil {
-				cStdout.Close()
-			}
-			if cStderr != nil {
-				cStderr.Close()
-			}
 		}
 		c.Log(DEBUG, "attach: stdin: end")
 		wg.Done()

--- a/daemon/pod/streams.go
+++ b/daemon/pod/streams.go
@@ -26,6 +26,14 @@ type StreamConfig struct {
 	stdinPipe io.WriteCloser
 }
 
+type StreamCloser struct {
+	*broadcaster.Unbuffered
+}
+
+func (sc *StreamCloser) Close() error {
+	return sc.Clean()
+}
+
 // NewStreamConfig creates a stream config and initializes
 // the standard err and standard out to new unbuffered broadcasters.
 func NewStreamConfig() *StreamConfig {
@@ -36,13 +44,13 @@ func NewStreamConfig() *StreamConfig {
 }
 
 // Stdout returns the standard output in the configuration.
-func (streamConfig *StreamConfig) Stdout() *broadcaster.Unbuffered {
-	return streamConfig.stdout
+func (streamConfig *StreamConfig) Stdout() io.WriteCloser {
+	return &StreamCloser{streamConfig.stdout}
 }
 
 // Stderr returns the standard error in the configuration.
-func (streamConfig *StreamConfig) Stderr() *broadcaster.Unbuffered {
-	return streamConfig.stderr
+func (streamConfig *StreamConfig) Stderr() io.WriteCloser {
+	return &StreamCloser{streamConfig.stderr}
 }
 
 // Stdin returns the standard input in the configuration.


### PR DESCRIPTION
fix #604

The container stopping should hup all streams if there are any.
Just check and reclaim any remains after a period should be safe.

Need update #585 later if this is approved

Signed-off-by: Wang Xu <gnawux@gmail.com>