### PR TITLE
add container stopped state

### DIFF
--- a/daemon/pod/container.go
+++ b/daemon/pod/container.go
@@ -39,6 +39,7 @@ const (
 	S_CONTAINER_CREATED
 	S_CONTAINER_RUNNING
 	S_CONTAINER_STOPPING
+	S_CONTAINER_STOPPED
 )
 
 type ContainerStatus struct {
@@ -204,20 +205,18 @@ func (c *Container) InfoStatus() *apitypes.ContainerStatus {
 		s.Waiting.Reason = "Pending"
 		s.Phase = "pending"
 	case S_CONTAINER_CREATED:
-		if c.status.FinishedAt != epocZero {
-			s.Terminated.StartedAt = c.status.StartedAt.Format(time.RFC3339)
-			s.Terminated.FinishedAt = c.status.FinishedAt.Format(time.RFC3339)
-			s.Terminated.ExitCode = int32(c.status.ExitCode)
-			if c.status.ExitCode != 0 || c.status.Killed {
-				s.Terminated.Reason = "Failed"
-				s.Phase = "failed"
-			} else {
-				s.Terminated.Reason = "Succeeded"
-				s.Phase = "succeeded"
-			}
+		s.Waiting.Reason = "Pending"
+		s.Phase = "pending"
+	case S_CONTAINER_STOPPED:
+		s.Terminated.StartedAt = c.status.StartedAt.Format(time.RFC3339)
+		s.Terminated.FinishedAt = c.status.FinishedAt.Format(time.RFC3339)
+		s.Terminated.ExitCode = int32(c.status.ExitCode)
+		if c.status.ExitCode != 0 || c.status.Killed {
+			s.Terminated.Reason = "Failed"
+			s.Phase = "failed"
 		} else {
-			s.Waiting.Reason = "Pending"
-			s.Phase = "pending"
+			s.Terminated.Reason = "Succeeded"
+			s.Phase = "succeeded"
 		}
 	case S_CONTAINER_RUNNING, S_CONTAINER_STOPPING:
 		s.Phase = "running"
@@ -318,7 +317,7 @@ func (c *Container) IsRunning() bool {
 
 func (c *Container) IsStopped() bool {
 	c.status.RLock()
-	stopped := c.status.State == S_CONTAINER_CREATED
+	stopped := c.status.State == S_CONTAINER_STOPPED
 	c.status.RUnlock()
 
 	return stopped
@@ -332,22 +331,19 @@ func (c *Container) BriefStatus() (s *apitypes.ContainerListResult) {
 		PodID:         c.p.Id(),
 	}
 	switch c.status.State {
-	case S_CONTAINER_NONE, S_CONTAINER_CREATING:
+	case S_CONTAINER_NONE, S_CONTAINER_CREATING, S_CONTAINER_CREATED:
 		s.Status = "pending"
 	case S_CONTAINER_RUNNING, S_CONTAINER_STOPPING:
 		s.Status = "running"
-	case S_CONTAINER_CREATED:
-		s.Status = "pending"
-		if !c.status.FinishedAt.Equal(epocZero) {
-			if c.status.ExitCode == 0 {
-				s.Status = "succeeded"
-			} else {
-				s.Status = "failed"
-			}
+	case S_CONTAINER_STOPPED:
+		if c.status.ExitCode == 0 {
+			s.Status = "succeeded"
+		} else {
+			s.Status = "failed"
 		}
 	default:
 	}
-	c.status.RUnlock()
+	defer c.status.RUnlock()
 	return s
 }
 
@@ -1216,7 +1212,7 @@ func (cs *ContainerStatus) Start() error {
 
 	if cs.State == S_CONTAINER_RUNNING {
 		return errors.ErrContainerAlreadyRunning
-	} else if cs.State != S_CONTAINER_CREATED {
+	} else if cs.State != S_CONTAINER_CREATED && cs.State != S_CONTAINER_STOPPED {
 		return fmt.Errorf("only CREATED container could be set to running, current: %d", cs.State)
 	}
 
@@ -1264,7 +1260,7 @@ func (cs *ContainerStatus) Stopped(t time.Time, exitCode int) bool {
 		cs.ExitCode = exitCode
 		result = true
 	}
-	cs.State = S_CONTAINER_CREATED
+	cs.State = S_CONTAINER_STOPPED
 	cs.stateChanged.Broadcast()
 	cs.Unlock()
 	return result
@@ -1285,7 +1281,7 @@ func (cs *ContainerStatus) IsStopped() bool {
 	cs.RLock()
 	defer cs.RUnlock()
 
-	return cs.State == S_CONTAINER_CREATED
+	return cs.State == S_CONTAINER_STOPPED
 }
 
 // AttachStreams connects streams to a TTY.


### PR DESCRIPTION
If a container is stopped and pod is still running, we end up hanging client on newer attach and exec. Add stopped state and deny new attach and exec when target container is stopped.

This does not address hanging client issue when attaching to a created state container, mostly because `hyperctl run` does attach before start. Do we want to change the order? I'm not convinced because otherwise client might miss some container output. What do you think? @gnawux 