### PR TITLE
Outstream

### DIFF
--- a/daemon/pod/exec.go
+++ b/daemon/pod/exec.go
@@ -81,11 +81,7 @@ func (wc *waitClose) Close() error {
 
 type writeCloser struct {
 	io.Writer
-	closer io.Closer
-}
-
-func (wc *writeCloser) Close() error {
-	return wc.closer.Close()
+	io.Closer
 }
 
 func (p *XPod) StartExec(stdin io.ReadCloser, stdout io.WriteCloser, containerId, execId string) error {

--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -217,3 +217,14 @@ hyper::test::force_kill_container() {
   sudo hyperctl rm $id
   test $res -eq 0
 }
+
+# regression test for #577
+hyper::test::container_logs_no_newline() {
+  echo "Container logs without newlines"
+  id=$(sudo hyperctl run -d busybox echo -n foobar | sed -ne "s/POD id is \(.*\)/\1/p")
+  sleep 3 # sleep a bit to let logger kick in
+  res=$(sudo hyperctl logs $id)
+  sudo hyperctl rm $id
+  echo logs result $res
+  test x$res = "xfoobar"
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -197,6 +197,7 @@ __EOF__
   hyper::test::specuseroverride
   hyper::test::imagevolume
   hyper::test::force_kill_container
+  hyper::test::container_logs_no_newline
 
   stop_hyperd
 }


### PR DESCRIPTION
The container logger copier expect to read EOF so that it can determine
the container output stream has ended. If we do not close stdout/stderr
streams, the logger copier will continue waiting for a new liner to stop
reading. When container stops and closes the logger, container logs are
lost forever.

fixes: #577  