### PR TITLE
fix aufs mount option length calculation

### DIFF
--- a/storage/aufs/aufs.go
+++ b/storage/aufs/aufs.go
@@ -87,7 +87,7 @@ func aufsMount(ro []string, rw, target, mountLabel string) (err error) {
 
 	offset := 54
 	if useDirperm() {
-		offset += len("dirperm1")
+		offset += len(",dirperm1")
 	}
 	b := make([]byte, syscall.Getpagesize()-len(mountLabel)-offset) // room for xino & mountLabel
 	bp := copy(b, fmt.Sprintf("br:%s=rw", rw))
@@ -107,6 +107,7 @@ func aufsMount(ro []string, rw, target, mountLabel string) (err error) {
 			} else {
 				data := utils.FormatMountLabel(fmt.Sprintf("append%s", layer), mountLabel)
 				if err = syscall.Mount("none", target, "aufs", MsRemount, data); err != nil {
+					glog.Errorf("error mounting aufs data(%s): %s", data, err.Error())
 					return
 				}
 			}
@@ -119,6 +120,7 @@ func aufsMount(ro []string, rw, target, mountLabel string) (err error) {
 			}
 			data := utils.FormatMountLabel(fmt.Sprintf("%s,%s", string(b[:bp]), opts), mountLabel)
 			if err = syscall.Mount("none", target, "aufs", 0, data); err != nil {
+				glog.Errorf("error first mounting aufs data(%d): %s", len(data), err.Error())
 				return
 			}
 			firstMount = false


### PR DESCRIPTION
Also add some error logs in case mount(2) fails.

The magic number `54` is a bit mysterious even the very first docker commit (https://github.com/moby/moby/commit/6d97339ca23ada27812572016ad4ff9ccffa8b09 https://github.com/moby/moby/pull/9151) did not bother to explain where it comes from...

Nevertheless, the length calculation when adding dirperm1 is clearly wrong though.