### PR TITLE
make ci runnable with forked repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 dist: trusty
 
 language: go
+go_import_path: github.com/hyperhq/hyperd
 
 go:
   - 1.8


### PR DESCRIPTION
Add `go_import_path` to import hyperhq/hyperd.