### PR TITLE
update binary packaging rules for 1.0 build

### DIFF
--- a/package/centos/rpm/SPECS/hyper-container.spec
+++ b/package/centos/rpm/SPECS/hyper-container.spec
@@ -35,7 +35,9 @@ make %{?_smp_mflags}
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_sysconfdir}
 mkdir -p %{buildroot}/lib/systemd/system/
-cp %{_builddir}/src/github.com/hyperhq/hyperd/{hyperctl,hyperd,vmlogd} %{buildroot}%{_bindir}
+cp %{_builddir}/src/github.com/hyperhq/hyperd/cmd/hyperd/hyperd %{buildroot}%{_bindir}
+cp %{_builddir}/src/github.com/hyperhq/hyperd/cmd/hyperctl/hyperctl %{buildroot}%{_bindir}
+cp %{_builddir}/src/github.com/hyperhq/hyperd/cmd/vmlogd/vmlogd %{buildroot}%{_bindir}
 cp -a %{_builddir}/src/github.com/hyperhq/hyperd/package/dist/etc/hyper %{buildroot}%{_sysconfdir}
 cp -a %{_builddir}/src/github.com/hyperhq/hyperd/package/dist/lib/systemd/system/hyperd.service %{buildroot}/lib/systemd/system/hyperd.service
 cp -a %{_builddir}/src/github.com/hyperhq/hyperd/package/dist/lib/systemd/system/hyper-vmlogd.service %{buildroot}/lib/systemd/system/hyper-vmlogd.service

--- a/package/centos/rpm/SPECS/hyperstart.spec
+++ b/package/centos/rpm/SPECS/hyperstart.spec
@@ -27,7 +27,7 @@ make %{?_smp_mflags}
 
 %install
 mkdir -p %{buildroot}%{_sharedstatedir}/hyper
-cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/kernel %{buildroot}%{_sharedstatedir}/hyper/
+cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/arch/`uname -m`/kernel %{buildroot}%{_sharedstatedir}/hyper/
 cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/hyper-initrd.img %{buildroot}%{_sharedstatedir}/hyper/
 
 %clean

--- a/package/debian/hypercontainer/debian/control
+++ b/package/debian/hypercontainer/debian/control
@@ -12,7 +12,7 @@ Vcs-Git: git://github.com/hyperhq/hyperd.git
 Vcs-Browser: https://github.com/hyperhq/hyperd
 
 Package: hypercontainer
-Architecture: amd64
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: HyperContainer - Virtualized Container Runtime
  Hyper is a VM based docker engine, it start container image in

--- a/package/debian/hypercontainer/debian/rules
+++ b/package/debian/hypercontainer/debian/rules
@@ -25,9 +25,9 @@ override_dh_auto_build:
 override_dh_auto_install:
 	echo "begin install"
 	mkdir -p debian/hypercontainer/usr/bin
-	cp -aT hyperd debian/hypercontainer/usr/bin/hyperd
-	cp -aT hyperctl debian/hypercontainer/usr/bin/hyperctl
-	cp -aT vmlogd debian/hypercontainer/usr/bin/vmlogd
+	cp -aT cmd/hyperd/hyperd debian/hypercontainer/usr/bin/hyperd
+	cp -aT cmd/hyperctl/hyperctl debian/hypercontainer/usr/bin/hyperctl
+	cp -aT cmd/vmlogd/vmlogd debian/hypercontainer/usr/bin/vmlogd
 	cp -r package/dist/* debian/hypercontainer/
 	echo "end install"
 

--- a/package/debian/hyperstart/debian/control
+++ b/package/debian/hyperstart/debian/control
@@ -10,7 +10,7 @@ Vcs-Git: git://github.com/hyperhq/hyperstart.git
 Vcs-Browser: https://github.com/hyperhq/hyperstart
 
 Package: hyperstart
-Architecture: amd64
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: The init Task for HyperContainer
  Hyperstart is the initrd for hyper VM, hyperstart 

--- a/package/debian/hyperstart/debian/rules
+++ b/package/debian/hyperstart/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir -p debian/hyperstart/var/lib/hyper/
-	cp -aT build/kernel debian/hyperstart/var/lib/hyper/kernel
+	cp -aT build/arch/`uname -m`/kernel debian/hyperstart/var/lib/hyper/kernel
 	cp -aT build/hyper-initrd.img debian/hyperstart/var/lib/hyper/hyper-initrd.img
 
 override_dh_auto_clean:

--- a/package/fedora/rpm/SPECS/hyper-container.spec
+++ b/package/fedora/rpm/SPECS/hyper-container.spec
@@ -33,7 +33,9 @@ make %{?_smp_mflags}
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_sysconfdir}
 mkdir -p %{buildroot}/lib/systemd/system/
-cp %{_builddir}/src/github.com/hyperhq/hyperd/{hyperctl,hyperd,vmlogd} %{buildroot}%{_bindir}
+cp %{_builddir}/src/github.com/hyperhq/hyperd/cmd/hyperd/hyperd %{buildroot}%{_bindir}
+cp %{_builddir}/src/github.com/hyperhq/hyperd/cmd/hyperctl/hyperctl %{buildroot}%{_bindir}
+cp %{_builddir}/src/github.com/hyperhq/hyperd/cmd/vmlogd/vmlogd %{buildroot}%{_bindir}
 cp -a %{_builddir}/src/github.com/hyperhq/hyperd/package/dist/etc/hyper %{buildroot}%{_sysconfdir}
 cp -a %{_builddir}/src/github.com/hyperhq/hyperd/package/dist/lib/systemd/system/hyperd.service %{buildroot}/lib/systemd/system/hyperd.service
 cp -a %{_builddir}/src/github.com/hyperhq/hyperd/package/dist/lib/systemd/system/hyper-vmlogd.service %{buildroot}/lib/systemd/system/hyper-vmlogd.service

--- a/package/fedora/rpm/SPECS/hyperstart.spec
+++ b/package/fedora/rpm/SPECS/hyperstart.spec
@@ -27,7 +27,7 @@ make %{?_smp_mflags}
 
 %install
 mkdir -p %{buildroot}%{_sharedstatedir}/hyper
-cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/kernel %{buildroot}%{_sharedstatedir}/hyper/
+cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/arch/`uname -m`/kernel %{buildroot}%{_sharedstatedir}/hyper/
 cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/hyper-initrd.img %{buildroot}%{_sharedstatedir}/hyper/
 
 %clean

--- a/package/ubuntu/hypercontainer/debian/control
+++ b/package/ubuntu/hypercontainer/debian/control
@@ -12,7 +12,7 @@ Vcs-Git: git://github.com/hyperhq/hyperd.git
 Vcs-Browser: https://github.com/hyperhq/hyperd
 
 Package: hypercontainer
-Architecture: amd64
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: HyperContainer - Virtualized Container Runtime
  Hyper is a VM based docker engine, it start container image in

--- a/package/ubuntu/hypercontainer/debian/rules
+++ b/package/ubuntu/hypercontainer/debian/rules
@@ -25,9 +25,9 @@ override_dh_auto_build:
 override_dh_auto_install:
 	echo "begin install"
 	mkdir -p debian/hypercontainer/usr/bin
-	cp -aT hyperd debian/hypercontainer/usr/bin/hyperd
-	cp -aT hyperctl debian/hypercontainer/usr/bin/hyperctl
-	cp -aT vmlogd debian/hypercontainer/usr/bin/vmlogd
+	cp -aT cmd/hyperd/hyperd debian/hypercontainer/usr/bin/hyperd
+	cp -aT cmd/hyperctl/hyperctl debian/hypercontainer/usr/bin/hyperctl
+	cp -aT cmd/vmlogd/vmlogd debian/hypercontainer/usr/bin/vmlogd
 	cp -r package/dist/* debian/hypercontainer/
 	echo "end install"
 

--- a/package/ubuntu/hyperstart/debian/control
+++ b/package/ubuntu/hyperstart/debian/control
@@ -10,7 +10,7 @@ Vcs-Git: git://github.com/hyperhq/hyperstart.git
 Vcs-Browser: https://github.com/hyperhq/hyperstart
 
 Package: hyperstart
-Architecture: amd64
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: The init Task for HyperContainer
  Hyperstart is the initrd for hyper VM, hyperstart 

--- a/package/ubuntu/hyperstart/debian/rules
+++ b/package/ubuntu/hyperstart/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir -p debian/hyperstart/var/lib/hyper/
-	cp -aT build/kernel debian/hyperstart/var/lib/hyper/kernel
+	cp -aT build/arch/`uname -m`/kernel debian/hyperstart/var/lib/hyper/kernel
 	cp -aT build/hyper-initrd.img debian/hyperstart/var/lib/hyper/hyper-initrd.img
 
 override_dh_auto_clean:


### PR DESCRIPTION
- enable the debian/ubuntu deb build for ARM64 arch
- #667 changed the hyperd binary path
- hyperhq/hyperstart#341 changed the kernel path

Signed-off-by: Wang Xu <gnawux@gmail.com>