### PR TITLE
fix storage base size support

### DIFF
--- a/cmd/hyperd/hyperd.go
+++ b/cmd/hyperd/hyperd.go
@@ -111,7 +111,7 @@ func mainDaemon(opt *Options) {
 		}
 	}
 
-	daemon.InitDockerCfg(strings.Split(opt.Mirrors, ","), strings.Split(opt.InsecureRegistries, ","), c.StorageDriver, c.Root)
+	daemon.InitDockerCfg(strings.Split(opt.Mirrors, ","), strings.Split(opt.InsecureRegistries, ","), c.StorageDriver, c.StorageBaseSize, c.Root)
 	d, err := daemon.NewDaemon(c)
 	if err != nil {
 		glog.Errorf("The hyperd create failed, %s", err.Error())

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -172,8 +172,12 @@ func InitDockerCfg(mirrors []string, insecureRegistries []string, graphdriver, b
 	dockerCfg.GraphDriver = graphdriver
 	dockerCfg.Root = root
 	dockerCfg.TrustKeyPath = path.Join(root, "keys")
-	if graphdriver == "devicemapper" && basesize != "" {
-		dockerCfg.GraphOptions = append(dockerCfg.GraphOptions, fmt.Sprintf("dm.basesize=%s", basesize))
+	if basesize != "" {
+		if graphdriver == "devicemapper" {
+			dockerCfg.GraphOptions = append(dockerCfg.GraphOptions, fmt.Sprintf("dm.basesize=%s", basesize))
+		} else if graphdriver == "rawblock" {
+			dockerCfg.GraphOptions = append(dockerCfg.GraphOptions, fmt.Sprintf("rawblock.basesize=%s", basesize))
+		}
 	}
 
 	// disable docker network

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -159,7 +159,7 @@ var (
 func presentInHelp(usage string) string { return usage }
 func absentFromHelp(string) string      { return "" }
 
-func InitDockerCfg(mirrors []string, insecureRegistries []string, graphdriver, root string) {
+func InitDockerCfg(mirrors []string, insecureRegistries []string, graphdriver, basesize, root string) {
 	if dockerCfg.LogConfig.Config == nil {
 		dockerCfg.LogConfig.Config = make(map[string]string)
 	}
@@ -172,6 +172,9 @@ func InitDockerCfg(mirrors []string, insecureRegistries []string, graphdriver, r
 	dockerCfg.GraphDriver = graphdriver
 	dockerCfg.Root = root
 	dockerCfg.TrustKeyPath = path.Join(root, "keys")
+	if graphdriver == "devicemapper" && basesize != "" {
+		dockerCfg.GraphOptions = append(dockerCfg.GraphOptions, fmt.Sprintf("dm.basesize=%s", basesize))
+	}
 
 	// disable docker network
 	flags.Set("-bridge", "none")

--- a/daemon/storage.go
+++ b/daemon/storage.go
@@ -210,7 +210,7 @@ func (dms *DevMapperStorage) CreateVolume(podId string, spec *apitypes.UserVolum
 		}
 		dev_id_str := strconv.Itoa(dev_id)
 
-		err = dm.CreateVolume(dms.VolPoolName, deviceName, dev_id_str, storage.DEFAULT_VOL_MKFS, storage.DEFAULT_DM_VOL_SIZE, restore)
+		err = dm.CreateVolume(dms.VolPoolName, deviceName, dev_id_str, storage.DEFAULT_VOL_MKFS, dms.DmPoolData.Size, restore)
 		if err != nil && !restore && strings.Contains(err.Error(), "failed: File exists") {
 			glog.V(1).Infof("retry for dev_id #%d creating collision: %v", dev_id, err)
 			continue

--- a/daemon/storage.go
+++ b/daemon/storage.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	dockertypes "github.com/docker/engine-api/types"
+	"github.com/docker/go-units"
 	"github.com/golang/glog"
 	"github.com/hyperhq/hyperd/daemon/daemondb"
 	"github.com/hyperhq/hyperd/storage"
@@ -105,8 +106,12 @@ func (dms *DevMapperStorage) RootPath() string {
 
 func (dms *DevMapperStorage) Init(c *apitypes.HyperConfig) error {
 	size := storage.DEFAULT_DM_POOL_SIZE
-	if c.StorageBaseSize > 0 {
-		size = c.StorageBaseSize
+	if c.StorageBaseSize != "" {
+		nsize, err := units.RAMInBytes(c.StorageBaseSize)
+		if err != nil {
+			return err
+		}
+		size = int(nsize)
 	}
 	dmPool := dm.DeviceMapper{
 		Datafile:         filepath.Join(utils.HYPER_ROOT, "lib") + "/data",

--- a/package/dist/etc/hyper/config
+++ b/package/dist/etc/hyper/config
@@ -30,6 +30,8 @@ Initrd=/var/lib/hyper/hyper-initrd.img
 
 # Storage driver for hyperd, valid value includes rawblock, devicemapper, overlay, and aufs
 # StorageDriver=overlay
+# StorageBaseSize only valid for devicemapper and rawblock
+# StorageBaseSize=10GB
 
 # Bridge device for hyperd, default is hyper0
 # Bridge=

--- a/types/config.go
+++ b/types/config.go
@@ -17,7 +17,7 @@ type HyperConfig struct {
 	Host            string
 	GRPCHost        string
 	StorageDriver   string
-	StorageBaseSize int
+	StorageBaseSize string
 	VmFactoryPolicy string
 	Driver          string
 	Kernel          string
@@ -56,7 +56,7 @@ func NewHyperConfig(config string) *HyperConfig {
 	}
 
 	c.StorageDriver, _ = cfg.GetValue(goconfig.DEFAULT_SECTION, "StorageDriver")
-	c.StorageBaseSize = cfg.MustInt(goconfig.DEFAULT_SECTION, "StorageBaseSize", 0)
+	c.StorageBaseSize, _ = cfg.GetValue(goconfig.DEFAULT_SECTION, "StorageBaseSize")
 	c.Kernel, _ = cfg.GetValue(goconfig.DEFAULT_SECTION, "Kernel")
 	c.Initrd, _ = cfg.GetValue(goconfig.DEFAULT_SECTION, "Initrd")
 	c.Bridge, _ = cfg.GetValue(goconfig.DEFAULT_SECTION, "Bridge")


### PR DESCRIPTION
When set, it is used to set both rootfs and volume size for rawblock and devicemapper graph drivers.

e.g., having `StorageBaseSize=3gb`:

```
[root@lear hyper]# hyperctl run -v /data --rm -t busybox
/ # df -h
Filesystem                Size      Used Available Use% Mounted on
/dev/sdb                  3.0G     33.4M      3.0G   1% /
devtmpfs                 53.5M         0     53.5M   0% /dev
tmpfs                    58.1M         0     58.1M   0% /dev/shm
/dev/sda                  3.0G     32.2M      3.0G   1% /data
share_dir                 1.0M      4.0K   1020.0K   0% /etc/hosts
```

cc @minz1027 