### PR TITLE
add missing mapping to interface id

### DIFF
--- a/daemon/pod/networks.go
+++ b/daemon/pod/networks.go
@@ -46,6 +46,7 @@ func (inf *Interface) prepare() error {
 			return err
 		}
 		inf.descript = &runv.InterfaceDescription{
+			Id:      inf.spec.Ifname,
 			Lo:      false,
 			Bridge:  setting.Bridge,
 			Ip:      setting.IPAddress,
@@ -57,6 +58,7 @@ func (inf *Interface) prepare() error {
 	}
 
 	inf.descript = &runv.InterfaceDescription{
+		Id:      inf.spec.Ifname,
 		Lo:      false,
 		Bridge:  inf.spec.Bridge,
 		Ip:      inf.spec.Ip,


### PR DESCRIPTION
Without mapping this field, interfaces will be persisted with a `0` id resulting in failed load on startup. This results in the entire pod and its containers not being loaded, and hyperd is not aware of them. However when a new pod with a container of the same name is created, the create will fail due to the name conflict with the previously existing container.

On startup hyperd will error with logs such as 
```
E1130 14:35:21.701591     791 persist.go:100] Pod[01C04VQSGYWSMM43B6NQJDSSFV] failed to load inf info of tapext384724640: leveldb: not found
```

Looking in the db, you can see that a key exists for `IF-01C04VQSGYWSMM43B6NQJDSSFV-0`, when it should be `IF-01C04VQSGYWSMM43B6NQJDSSFV-tapext384724640`.

It looks like https://github.com/hyperhq/hyperd/commit/7236f254f31a83d49ca5f8686d8ab0252cc21d5f#diff-6f66fd8047c9260ef4f28dad4289e1a4 seems to have removed this mapping.

Adding this mapping back resolves this issue.

Let me know if I'm perhaps missing some context and this is the way it should be.