### PR TITLE
Fix portmapping failure: bad IP address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y -qq autoconf automake pkg-config libdevmapper-dev libsqlite3-dev libvirt-dev libvirt-bin aufs-tools wget libaio1 libpixman-1-0
+  - sudo apt-get install -y -qq autoconf automake pkg-config libdevmapper-dev libsqlite3-dev libvirt-dev libvirt-bin aufs-tools wget libaio1 libpixman-1-0 netcat
   - wget https://s3-us-west-1.amazonaws.com/hypercontainer-download/qemu-hyper/qemu-hyper_2.4.1-1_amd64.deb && sudo dpkg -i --force-all qemu-hyper_2.4.1-1_amd64.deb
   - cd `mktemp -d`
   - mkdir -p ${GOPATH}/src/github.com/hyperhq

--- a/daemon/pod/provision.go
+++ b/daemon/pod/provision.go
@@ -3,6 +3,7 @@ package pod
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -419,7 +420,8 @@ func (p *XPod) prepareResources() error {
 			return err
 		}
 		if p.containerIP == "" {
-			p.containerIP = inf.descript.Ip
+			fields := strings.SplitN(inf.descript.Ip, "/", 2)
+			p.containerIP = fields[0]
 		}
 	}
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -199,6 +199,7 @@ __EOF__
   hyper::test::force_kill_container
   hyper::test::container_logs_no_newline
   hyper::test::container_readonly_rootfs_and_volume
+  hyper::test::portmapping
 
   stop_hyperd
 }


### PR DESCRIPTION
fix portmapping failure introduced by hyperhq/runv#592, in which the format of ip field was changed to cidr format.

An test case for portmapping was introduced in this PR.

Signed-off-by: Wang Xu <gnawux@gmail.com>