### PR TITLE
hack/test-cmd.sh: change test image from "busybox" to "hyperhq/busybox"

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -28,14 +28,14 @@ hyper::test::remove_image() {
 
 hyper::test::exitcode() {
   echo "Pod exit code test"
-  res=$(sudo hyperctl run --rm busybox sh -c "exit 17" > /dev/null 2>&1 ; echo $?)
+  res=$(sudo hyperctl run --rm hyperhq/busybox sh -c "exit 17" > /dev/null 2>&1 ; echo $?)
   echo "should return 17, return: $res"
   test $res -eq 17
 }
 
 hyper::test::exec() {
   echo "Pod exec and exit code test"
-  id=$(sudo hyperctl run -d busybox /bin/sh | sed -ne "s/POD id is \(.*\)/\1/p")
+  id=$(sudo hyperctl run -d hyperhq/busybox /bin/sh | sed -ne "s/POD id is \(.*\)/\1/p")
   echo "test pod ID is $id"
   res=$(sudo hyperctl exec $id sh -c "exit 37" > /dev/null 2>&1 ; echo $?)
   echo "should return 37, return: $res"
@@ -147,7 +147,7 @@ hyper::test::integration() {
 
 hyper::test::execvm() {
   echo "Pod execvm echo test"
-  id=$(sudo hyperctl run -d busybox /bin/sh | sed -ne "s/POD id is \(.*\)/\1/p")
+  id=$(sudo hyperctl run -d hyperhq/busybox /bin/sh | sed -ne "s/POD id is \(.*\)/\1/p")
   echo "test pod ID is $id"
   res=$(sudo hyperctl exec -m $id /sbin/busybox sh -c "echo aaa")
   echo "should return aaa, actual: $res"
@@ -221,7 +221,7 @@ hyper::test::force_kill_container() {
 # regression test for #577
 hyper::test::container_logs_no_newline() {
   echo "Container logs without newlines"
-  id=$(sudo hyperctl run -d busybox echo -n foobar | sed -ne "s/POD id is \(.*\)/\1/p")
+  id=$(sudo hyperctl run -d hyperhq/busybox echo -n foobar | sed -ne "s/POD id is \(.*\)/\1/p")
   sleep 3 # sleep a bit to let logger kick in
   res=$(sudo hyperctl logs $id)
   sudo hyperctl rm $id
@@ -262,5 +262,5 @@ END
     else
       return 1
     fi
-  done < <(sudo hyperctl run -t --rm --publish 3000:1300 busybox:latest sh -c 'echo "start" ; nc -l -p 1300')
+  done < <(sudo hyperctl run -t --rm --publish 3000:1300 hyperhq/busybox:latest sh -c 'echo "start" ; nc -l -p 1300')
 }

--- a/hack/pods/busybox-tty.pod
+++ b/hack/pods/busybox-tty.pod
@@ -2,7 +2,7 @@
         "id": "test-container-force-killing",
         "containers" : [{
             "name": "busybox-with-tty",
-            "image": "busybox",
+            "image": "hyperhq/busybox",
             "command": ["/bin/sh"]
         }],
         "resource": {

--- a/hack/pods/file-mapping.pod
+++ b/hack/pods/file-mapping.pod
@@ -2,7 +2,7 @@
         "id": "test-file-mapping",
         "containers" : [{
             "name": "mapping",
-            "image": "busybox",
+            "image": "hyperhq/busybox",
             "command": ["/bin/sh", "-c", "md5sum /root/resolv.conf"],
             "volumes": [{
                 "volume": "resolv.conf",

--- a/hack/pods/hostname-err-char.pod
+++ b/hack/pods/hostname-err-char.pod
@@ -3,7 +3,7 @@
 	"hostname": "/myname",
 	"containers" : [{
 	    "name": "file-tester",
-	    "image": "busybox:latest",
+	    "image": "hyperhq/busybox:latest",
 	    "workdir": "/",
 	    "command": ["hostname"]
 	}],

--- a/hack/pods/hostname-err-long.pod
+++ b/hack/pods/hostname-err-long.pod
@@ -3,7 +3,7 @@
 	"hostname": "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn",
 	"containers" : [{
 	    "name": "file-tester",
-	    "image": "busybox:latest",
+	    "image": "hyperhq/busybox:latest",
 	    "workdir": "/",
 	    "command": ["hostname"]
 	}],

--- a/hack/pods/hostname.pod
+++ b/hack/pods/hostname.pod
@@ -3,7 +3,7 @@
 	"hostname": "myname",
 	"containers" : [{
 	    "name": "file-tester",
-	    "image": "busybox:latest",
+	    "image": "hyperhq/busybox:latest",
 	    "workdir": "/",
 	    "command": ["hostname"]
 	}],

--- a/hack/pods/insert-file.pod
+++ b/hack/pods/insert-file.pod
@@ -2,7 +2,7 @@
 	"id": "test-inject-file",
 	"containers" : [{
 	    "name": "file-tester",
-	    "image": "busybox:latest",
+	    "image": "hyperhq/busybox:latest",
 	    "workdir": "/",
 	    "command": ["/bin/sh", "-c", "cd /root/test/; md5sum resolv.conf logo.png t1 t2 t3"],
 		"files": [{

--- a/hack/pods/nfs-client.pod
+++ b/hack/pods/nfs-client.pod
@@ -4,7 +4,7 @@
     "memory": 256
   },
   "containers": [{
-      "image": "busybox",
+      "image": "hyperhq/busybox",
       "volumes": [{
 	"volume": "sharevolume",
 	"path": "/export",

--- a/hack/pods/readonly-rootfs.pod
+++ b/hack/pods/readonly-rootfs.pod
@@ -1,7 +1,7 @@
 {
         "containers" : [{
             "name": "busybox-readonly",
-            "image": "busybox",
+            "image": "hyperhq/busybox",
             "command": ["/bin/sh"],
             "readonly": true,
             "volumes": [{

--- a/hack/pods/service.pod
+++ b/hack/pods/service.pod
@@ -1,7 +1,7 @@
 {
             "containers": [
                 {
-                    "image": "busybox:latest",
+                    "image": "hyperhq/busybox:latest",
                     "name": "service",
                     "command": ["/bin/sh", "-c", "ps aux"]
                 }

--- a/hack/pods/simple-volume.pod
+++ b/hack/pods/simple-volume.pod
@@ -2,7 +2,7 @@
         "id": "test-remove-container-with-volume",
         "containers" : [{
             "name": "container-with-volume",
-            "image": "busybox",
+            "image": "hyperhq/busybox",
             "volumes": [{
                 "volume": "tmp",
                 "path": "/mnt",

--- a/hack/pods/with-volume.pod
+++ b/hack/pods/with-volume.pod
@@ -2,7 +2,7 @@
 	"id": "test-container-volume",
 	"containers" : [{
 	    "name": "c1",
-	    "image": "busybox",
+	    "image": "hyperhq/busybox",
             "command": ["/bin/sh", "-c", "grep -q 'hello, world' /mnt/with-volume-test-1 && df | grep -q '/var/log' && echo 'container 1 OK' ; sleep 5"],
             "volumes": [{
                 "volume": "log",
@@ -16,7 +16,7 @@
 	},
 	{
 	    "name": "c2",
-	    "image": "busybox",
+	    "image": "hyperhq/busybox",
 	    "workdir": "/",
 	    "command": ["/bin/sh", "-c", "echo 'container-2 OK' > /mnt/with-volume-test-2"],
             "volumes": [{

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -160,14 +160,14 @@ __EOF__
   # Image management   #
   ######################
 
-  hyper::test::check_image busybox || hyper::test::pull_image busybox
-  hyper::test::check_image busybox
+  hyper::test::check_image "hyperhq/busybox" || hyper::test::pull_image "hyperhq/busybox"
+  hyper::test::check_image "hyperhq/busybox"
 
-  hyper::test::remove_image busybox
-  ! hyper::test::check_image busybox
+  hyper::test::remove_image "hyperhq/busybox"
+  ! hyper::test::check_image "hyperhq/busybox"
 
-  hyper::test::pull_image busybox
-  hyper::test::check_image busybox
+  hyper::test::pull_image "hyperhq/busybox"
+  hyper::test::check_image "hyperhq/busybox"
 
   hyper::test::pull_image "haproxy:1.5"
   hyper::test::check_image "haproxy" "1.5"

--- a/integration/hyper_test.go
+++ b/integration/hyper_test.go
@@ -84,13 +84,13 @@ func (s *TestSuite) TestGetContainerLogs(c *C) {
 }
 
 func (s *TestSuite) TestPostAttach(c *C) {
-	err := s.client.PullImage("busybox", "latest", nil)
+	err := s.client.PullImage("hyperhq/busybox", "latest", nil)
 	c.Assert(err, IsNil)
 
 	spec := types.UserPod{
 		Containers: []*types.UserContainer{
 			{
-				Image: "busybox",
+				Image: "hyperhq/busybox",
 			},
 		},
 	}
@@ -132,7 +132,7 @@ func (s *TestSuite) TestCreateAndStartPod(c *C) {
 		Id: "busybox",
 		Containers: []*types.UserContainer{
 			{
-				Image: "busybox",
+				Image: "hyperhq/busybox",
 			},
 		},
 	}
@@ -168,7 +168,7 @@ func (s *TestSuite) TestCreateAndStartPod(c *C) {
 }
 
 func (s *TestSuite) TestCreateContainer(c *C) {
-	err := s.client.PullImage("busybox", "latest", nil)
+	err := s.client.PullImage("hyperhq/busybox", "latest", nil)
 	c.Assert(err, IsNil)
 
 	spec := types.UserPod{}
@@ -177,7 +177,7 @@ func (s *TestSuite) TestCreateContainer(c *C) {
 	c.Logf("Pod created: %s", pod)
 
 	container, err := s.client.CreateContainer(pod, &types.UserContainer{
-		Image: "busybox",
+		Image: "hyperhq/busybox",
 	})
 	c.Assert(err, IsNil)
 	c.Logf("Container created: %s", container)
@@ -191,7 +191,7 @@ func (s *TestSuite) TestCreateContainer(c *C) {
 }
 
 func (s *TestSuite) TestRenameContainer(c *C) {
-	err := s.client.PullImage("busybox", "latest", nil)
+	err := s.client.PullImage("hyperhq/busybox", "latest", nil)
 	c.Assert(err, IsNil)
 
 	spec := types.UserPod{}
@@ -200,7 +200,7 @@ func (s *TestSuite) TestRenameContainer(c *C) {
 	c.Logf("Pod created: %s", pod)
 
 	container, err := s.client.CreateContainer(pod, &types.UserContainer{
-		Image: "busybox",
+		Image: "hyperhq/busybox",
 	})
 	c.Assert(err, IsNil)
 	c.Logf("Container created: %s", container)
@@ -259,11 +259,11 @@ func (s *TestSuite) TestAddListDeleteService(c *C) {
 	spec := types.UserPod{
 		Containers: []*types.UserContainer{
 			{
-				Image:   "busybox",
+				Image:   "hyperhq/busybox",
 				Command: []string{"sleep", "10000"},
 			},
 			{
-				Image:   "busybox",
+				Image:   "hyperhq/busybox",
 				Command: []string{"sleep", "10000"},
 			},
 		},
@@ -358,7 +358,7 @@ func (s *TestSuite) TestStartAndStopPod(c *C) {
 		Id: "busybox",
 		Containers: []*types.UserContainer{
 			{
-				Image: "busybox",
+				Image: "hyperhq/busybox",
 			},
 		},
 	}
@@ -391,7 +391,7 @@ func (s *TestSuite) TestSetPodLabels(c *C) {
 		Id: "busybox",
 		Containers: []*types.UserContainer{
 			{
-				Image: "busybox",
+				Image: "hyperhq/busybox",
 			},
 		},
 	}
@@ -419,7 +419,7 @@ func (s *TestSuite) TestPauseAndUnpausePod(c *C) {
 		Id: "busybox",
 		Containers: []*types.UserContainer{
 			{
-				Image: "busybox",
+				Image: "hyperhq/busybox",
 			},
 		},
 	}
@@ -466,7 +466,7 @@ func (s *TestSuite) TestGetPodStats(c *C) {
 		Id: "busybox",
 		Containers: []*types.UserContainer{
 			{
-				Image: "busybox",
+				Image: "hyperhq/busybox",
 			},
 		},
 	}
@@ -509,7 +509,7 @@ func (s *TestSuite) TestSendContainerSignal(c *C) {
 		c.Assert(err, IsNil)
 	}()
 
-	container, err := s.client.CreateContainer(pod, &types.UserContainer{Image: "busybox"})
+	container, err := s.client.CreateContainer(pod, &types.UserContainer{Image: "hyperhq/busybox"})
 	c.Assert(err, IsNil)
 	c.Logf("Container created: %s", container)
 
@@ -540,7 +540,7 @@ func (s *TestSuite) TestSendExecSignal(c *C) {
 		Containers: []*types.UserContainer{
 			{
 				Name:  cName,
-				Image: "busybox",
+				Image: "hyperhq/busybox",
 			},
 		},
 	}
@@ -600,7 +600,7 @@ func (s *TestSuite) TestTTYResize(c *C) {
 		Containers: []*types.UserContainer{
 			{
 				Name:  cName,
-				Image: "busybox",
+				Image: "hyperhq/busybox",
 				Tty:   true,
 			},
 		},


### PR DESCRIPTION
Meet a issue that hyper::test::portmapping hang and it is a bug of
busybox image "https://github.com/docker-library/busybox/issues/44"
(It is closed but actually it is not fixed).

After discussion with @gnawux and @bergwolf, all of us think test with a image
that under control is better than use normal busybox image.

So @bergwolf add "hyperhq/busybox" image and let test use it.

Signed-off-by: Hui Zhu <teawater@hyper.sh>