### PR TITLE
XPod: doStopPod: call removeFromSandbox with every p.containers

### DIFF
--- a/daemon/pod/decommission.go
+++ b/daemon/pod/decommission.go
@@ -382,6 +382,13 @@ func (p *XPod) doStopPod(graceful int) error {
 		return nil
 	}
 
+	for cid, c := range p.containers {
+		err = c.removeFromSandbox()
+		if err != nil {
+			c.Log(ERROR, "failed to remove %s from sandbox", cid)
+		}
+	}
+
 	p.Log(INFO, "stop container success, shutdown sandbox")
 	result := p.sandbox.Shutdown()
 	if result.IsSuccess() {


### PR DESCRIPTION
Some resource for containers needs to be released before p.sandbox.Shutdown.

Add this patch to call removeFromSandbox with every p.containers before p.sandbox.Shutdown to release the resource.
