### PR TITLE
network: provide a default interface MTU

### DIFF
--- a/daemon/pod/networks.go
+++ b/daemon/pod/networks.go
@@ -16,6 +16,8 @@ type Interface struct {
 	descript *runv.InterfaceDescription
 }
 
+const defaultInterfaceMtu = 1500
+
 func newInterface(p *XPod, spec *apitypes.UserInterface) *Interface {
 	return &Interface{p: p, spec: spec}
 }
@@ -37,6 +39,11 @@ func (inf *Interface) prepare() error {
 		err := fmt.Errorf("if configured a bridge, must specify the IP address")
 		inf.Log(ERROR, err)
 		return err
+	}
+
+	mtu := inf.spec.Mtu
+	if mtu == 0 {
+		mtu = defaultInterfaceMtu
 	}
 
 	if inf.spec.Ip == "" {


### PR DESCRIPTION
Now that we've decleared that the Mtu field in types.UserInterface
is optional, we need to provide a default value so that missing
Mtu field won't break interface handling.