### PR TITLE
Container.terminate: ignore the error of c.p.sandbox.KillContainer wi…

### DIFF
--- a/daemon/pod/container.go
+++ b/daemon/pod/container.go
@@ -1112,6 +1112,10 @@ func (c *Container) terminate(force bool) (err error) {
 	c.Log(DEBUG, "stopping: killing container with %d", sig)
 	err = c.p.sandbox.KillContainer(c.Id(), sig)
 	if err != nil {
+		if !c.IsRunning() {
+			c.Log(ERROR, "failed to kill container: %v.  Container state %v is not running(3), ignore this error", err, c.CurrentState())
+			return nil
+		}
 		c.Log(ERROR, "failed to kill container: %v", err)
 	}
 


### PR DESCRIPTION
…th not running container

Got following errors when exit the container that has tty:
E0307 16:28:24.727935  114589 container.go:1115] Pod[busybox-4107240543] Con[b47e9f433fad(busybox-4107240543)] failed to kill container: Error:
E0307 16:28:24.727970  114589 decommission.go:421] Pod[busybox-4107240543] exception during stop all containers: finished with errors: map[b47e9f433fad09406e0e179308309e5b3282651c0810a377cbfddc07e5d43f6e:Error: ]
I0307 16:28:24.727982  114589 decommission.go:380] Pod[busybox-4107240543] stop container failed, force quit sandbox

The reason is when exit in the tty, the container has already exited
with itself.  For example:
I0307 16:28:24.642275  114589 json.go:368] SB[vm-djYGsULyQq] readVmMessage code: 23, len: 127
I0307 16:28:24.642309  114589 json.go:378] SB[vm-djYGsULyQq] ProcessAsyncEvent: {"container":"b47e9f433fad09406e0e179308309e5b3282651c0810a377cbfddc07e5d43f6e","process":"init","event":"finished","status":0}
I0307 16:28:24.642430  114589 vm_states.go:61] SB[vm-djYGsULyQq] Con[b47e9f433fad09406e0e179308309e5b3282651c0810a377cbfddc07e5d43f6e] container finished, unset iostream pipes
I0307 16:28:24.642476  114589 vm.go:207] SB[vm-djYGsULyQq] got shut down msg, acked here
I0307 16:28:24.642513  114589 vm.go:209] SB[vm-djYGsULyQq] got shut down msg, acked somewhere
I0307 16:28:24.642624  114589 container.go:1067] Pod[busybox-4107240543] Con[b47e9f433fad(busybox-4107240543)] container exited with code 0 (at 2018-03-07 08:28:24.642486336 +0000 UTC)
I0307 16:28:24.642659  114589 container.go:1073] Pod[busybox-4107240543] Con[b47e9f433fad(busybox-4107240543)] clean up container

Then hyperstart will not find the container when it got signal:
I0307 16:28:24.658264  114589 vm_console.go:100] SB[vm-djYGsULyQq] [CNL] hyper_ttyfd_handle seq 1, len 0
I0307 16:28:24.660397  114589 vm_console.go:100] SB[vm-djYGsULyQq] [CNL] can't find exec whose seq is 1

So c.p.sandbox.KillContainer will get error.

This patch let Container.terminate just ignore this error.

Signed-off-by: Hui Zhu <teawater@hyper.sh>