### PR TITLE
Daemon.RemovePod: change p.IsAlive to !p.IsStopped

### DIFF
--- a/daemon/rm.go
+++ b/daemon/rm.go
@@ -26,7 +26,7 @@ func (daemon *Daemon) RemovePod(podId string) (int, string, error) {
 
 	daemon.PodList.Release(podId)
 
-	if p.IsAlive() {
+	if !p.IsStopped() {
 		glog.V(1).Infof("remove pod %s, stop it firstly", podId)
 		p.Stop(5)
 	}


### PR DESCRIPTION
When pod get some error, its status will be set to not running but
its qemu is still running.
So change to remove check to handle the issue.

Signed-off-by: Hui Zhu <teawater@hyper.sh>