### PR TITLE
Remove snapContainers and snapVolumes and use other way to handle the lock issue of XPod.updatePodInfo

### DIFF
--- a/daemon/pod/container.go
+++ b/daemon/pod/container.go
@@ -135,7 +135,9 @@ func (c *Container) CreatedAt() time.Time {
 	return ct
 }
 
-func (c *Container) InfoLocked() *apitypes.Container {
+func (c *Container) Info() *apitypes.Container {
+	c.status.RLock()
+	defer c.status.RUnlock()
 	cinfo := &apitypes.Container{
 		Name:            c.RuntimeName(),
 		ContainerID:     c.Id(),
@@ -186,13 +188,9 @@ func (c *Container) InfoLocked() *apitypes.Container {
 	return cinfo
 }
 
-func (c *Container) Info() *apitypes.Container {
+func (c *Container) InfoStatus() *apitypes.ContainerStatus {
 	c.status.RLock()
 	defer c.status.RUnlock()
-	return c.InfoLocked()
-}
-
-func (c *Container) InfoStatusLocked() *apitypes.ContainerStatus {
 	s := &apitypes.ContainerStatus{
 		Name:        c.SpecName(),
 		ContainerID: c.Id(),
@@ -226,12 +224,6 @@ func (c *Container) InfoStatusLocked() *apitypes.ContainerStatus {
 	}
 	c.Log(DEBUG, "retrive info %#v from status %#v", s, c.status)
 	return s
-}
-
-func (c *Container) InfoStatus() *apitypes.ContainerStatus {
-	c.status.RLock()
-	defer c.status.RUnlock()
-	return c.InfoStatusLocked()
 }
 
 // Container life cycle operations:

--- a/daemon/pod/decommission.go
+++ b/daemon/pod/decommission.go
@@ -276,9 +276,6 @@ func (p *XPod) RemoveContainer(id string) error {
 	}
 	p.factory.registry.ReleaseContainer(id, c.SpecName())
 	delete(p.containers, id)
-	p.statusLock.Lock()
-	delete(p.snapContainers, id)
-	p.statusLock.Unlock()
 
 	//remove volumes from daemondb
 	for _, vName := range removedVols {

--- a/daemon/pod/decommission.go
+++ b/daemon/pod/decommission.go
@@ -275,7 +275,9 @@ func (p *XPod) RemoveContainer(id string) error {
 		return err
 	}
 	p.factory.registry.ReleaseContainer(id, c.SpecName())
+	p.statusLock.Lock()
 	delete(p.containers, id)
+	p.statusLock.Unlock()
 
 	//remove volumes from daemondb
 	for _, vName := range removedVols {

--- a/daemon/pod/persist.go
+++ b/daemon/pod/persist.go
@@ -381,9 +381,6 @@ func (p *XPod) loadContainer(id string) error {
 		return err
 	}
 	p.containers[c.Id()] = c
-	p.statusLock.Lock()
-	p.snapContainers[c.Id()] = c
-	p.statusLock.Unlock()
 	return nil
 }
 

--- a/daemon/pod/persist.go
+++ b/daemon/pod/persist.go
@@ -125,9 +125,11 @@ func LoadXPod(factory *PodFactory, layout *types.PersistPodLayout) (*XPod, error
 
 	// if sandbox is running, set all volume INSERTED
 	if p.status == S_POD_RUNNING {
+		p.statusLock.Lock()
 		for _, v := range p.volumes {
 			v.status = S_VOLUME_INSERTED
 		}
+		p.statusLock.Unlock()
 	}
 
 	err = p.loadPodMeta()
@@ -375,7 +377,9 @@ func (p *XPod) loadContainer(id string) error {
 		p.Log(ERROR, "failed to register name of container %s (%s) during load", c.Id(), c.SpecName(), err)
 		return err
 	}
+	p.statusLock.Lock()
 	p.containers[c.Id()] = c
+	p.statusLock.Unlock()
 	return nil
 }
 
@@ -402,7 +406,9 @@ func (p *XPod) loadVolume(id string) error {
 	v := newVolume(p, vx.Spec)
 	v.descript = vx.Descript
 	v.status = S_VOLUME_CREATED
+	p.statusLock.Lock()
 	p.volumes[v.spec.Name] = v
+	p.statusLock.Unlock()
 	return nil
 }
 

--- a/daemon/pod/persist.go
+++ b/daemon/pod/persist.go
@@ -128,11 +128,6 @@ func LoadXPod(factory *PodFactory, layout *types.PersistPodLayout) (*XPod, error
 		for _, v := range p.volumes {
 			v.status = S_VOLUME_INSERTED
 		}
-		p.statusLock.Lock()
-		for index := range p.snapVolumes {
-			p.snapVolumes[index] = p.volumes[index].Info()
-		}
-		p.statusLock.Unlock()
 	}
 
 	err = p.loadPodMeta()
@@ -408,9 +403,6 @@ func (p *XPod) loadVolume(id string) error {
 	v.descript = vx.Descript
 	v.status = S_VOLUME_CREATED
 	p.volumes[v.spec.Name] = v
-	p.statusLock.Lock()
-	p.snapVolumes[v.spec.Name] = p.volumes[v.spec.Name].Info()
-	p.statusLock.Unlock()
 	return nil
 }
 

--- a/daemon/pod/pod.go
+++ b/daemon/pod/pod.go
@@ -78,9 +78,6 @@ type XPod struct {
 	// on it too.
 	stoppedChan chan bool
 	initCond    *sync.Cond
-
-	//Protected by statusLock
-	snapVolumes map[string]*apitypes.PodVolume
 }
 
 // The Log infrastructure, to add pod name as prefix of the log message.
@@ -347,14 +344,14 @@ func (p *XPod) updatePodInfo() error {
 
 	var (
 		containers      = make([]*apitypes.Container, 0, len(p.containers))
-		volumes         = make([]*apitypes.PodVolume, 0, len(p.snapVolumes))
+		volumes         = make([]*apitypes.PodVolume, 0, len(p.volumes))
 		containerStatus = make([]*apitypes.ContainerStatus, 0, len(p.containers))
 	)
 
 	p.info.Spec.Labels = p.labels
 
-	for _, v := range p.snapVolumes {
-		volumes = append(volumes, v)
+	for _, v := range p.volumes {
+		volumes = append(volumes, v.Info())
 	}
 	p.info.Spec.Volumes = volumes
 

--- a/daemon/pod/pod.go
+++ b/daemon/pod/pod.go
@@ -80,8 +80,7 @@ type XPod struct {
 	initCond    *sync.Cond
 
 	//Protected by statusLock
-	snapVolumes    map[string]*apitypes.PodVolume
-	snapContainers map[string]*Container
+	snapVolumes map[string]*apitypes.PodVolume
 }
 
 // The Log infrastructure, to add pod name as prefix of the log message.
@@ -347,9 +346,9 @@ func (p *XPod) updatePodInfo() error {
 	defer p.statusLock.Unlock()
 
 	var (
-		containers      = make([]*apitypes.Container, 0, len(p.snapContainers))
+		containers      = make([]*apitypes.Container, 0, len(p.containers))
 		volumes         = make([]*apitypes.PodVolume, 0, len(p.snapVolumes))
-		containerStatus = make([]*apitypes.ContainerStatus, 0, len(p.snapContainers))
+		containerStatus = make([]*apitypes.ContainerStatus, 0, len(p.containers))
 	)
 
 	p.info.Spec.Labels = p.labels
@@ -360,9 +359,9 @@ func (p *XPod) updatePodInfo() error {
 	p.info.Spec.Volumes = volumes
 
 	succeeeded := "Succeeded"
-	for _, c := range p.snapContainers {
-		ci := c.InfoLocked()
-		cs := c.InfoStatusLocked()
+	for _, c := range p.containers {
+		ci := c.Info()
+		cs := c.InfoStatus()
 		containers = append(containers, ci)
 		containerStatus = append(containerStatus, cs)
 		if cs.Phase == "failed" {

--- a/daemon/pod/pod.go
+++ b/daemon/pod/pod.go
@@ -339,8 +339,8 @@ func (p *XPod) initPodInfo() {
 }
 
 func (p *XPod) updatePodInfo() error {
-	p.statusLock.Lock()
-	defer p.statusLock.Unlock()
+	p.statusLock.RLock()
+	defer p.statusLock.RUnlock()
 
 	var (
 		containers      = make([]*apitypes.Container, 0, len(p.containers))

--- a/daemon/pod/provision.go
+++ b/daemon/pod/provision.go
@@ -101,7 +101,6 @@ func newXPod(factory *PodFactory, spec *apitypes.UserPod) (*XPod, error) {
 		statusLock:    &sync.RWMutex{},
 		stoppedChan:   make(chan bool, 1),
 		factory:       factory,
-		snapVolumes:   make(map[string]*apitypes.PodVolume),
 	}
 	p.initCond = sync.NewCond(p.statusLock.RLocker())
 	return p, nil
@@ -153,9 +152,6 @@ func (p *XPod) doContainerCreate(c *apitypes.UserContainer) (string, error) {
 			continue
 		}
 		p.volumes[vol.Name] = newVolume(p, vol)
-		p.statusLock.Lock()
-		p.snapVolumes[vol.Name] = p.volumes[vol.Name].Info()
-		p.statusLock.Unlock()
 		nvs = append(nvs, vol.Name)
 	}
 	pc.Log(TRACE, "volumes to be added: %v", nvs)
@@ -377,9 +373,6 @@ func (p *XPod) initResources(spec *apitypes.UserPod, allowCreate bool) error {
 				continue
 			}
 			p.volumes[vol.Name] = newVolume(p, vol)
-			p.statusLock.Lock()
-			p.snapVolumes[vol.Name] = p.volumes[vol.Name].Info()
-			p.statusLock.Unlock()
 		}
 	}
 

--- a/daemon/pod/provision.go
+++ b/daemon/pod/provision.go
@@ -87,22 +87,21 @@ func newXPod(factory *PodFactory, spec *apitypes.UserPod) (*XPod, error) {
 	factory.hosts = HostsCreator(spec.Id)
 	factory.logCreator = initLogCreator(factory, spec)
 	p := &XPod{
-		name:           spec.Id,
-		logPrefix:      fmt.Sprintf("Pod[%s] ", spec.Id),
-		globalSpec:     spec.CloneGlobalPart(),
-		containers:     make(map[string]*Container),
-		volumes:        make(map[string]*Volume),
-		interfaces:     make(map[string]*Interface),
-		portMappings:   spec.Portmappings,
-		labels:         spec.Labels,
-		prestartExecs:  [][]string{},
-		execs:          make(map[string]*Exec),
-		resourceLock:   &sync.Mutex{},
-		statusLock:     &sync.RWMutex{},
-		stoppedChan:    make(chan bool, 1),
-		factory:        factory,
-		snapVolumes:    make(map[string]*apitypes.PodVolume),
-		snapContainers: make(map[string]*Container),
+		name:          spec.Id,
+		logPrefix:     fmt.Sprintf("Pod[%s] ", spec.Id),
+		globalSpec:    spec.CloneGlobalPart(),
+		containers:    make(map[string]*Container),
+		volumes:       make(map[string]*Volume),
+		interfaces:    make(map[string]*Interface),
+		portMappings:  spec.Portmappings,
+		labels:        spec.Labels,
+		prestartExecs: [][]string{},
+		execs:         make(map[string]*Exec),
+		resourceLock:  &sync.Mutex{},
+		statusLock:    &sync.RWMutex{},
+		stoppedChan:   make(chan bool, 1),
+		factory:       factory,
+		snapVolumes:   make(map[string]*apitypes.PodVolume),
 	}
 	p.initCond = sync.NewCond(p.statusLock.RLocker())
 	return p, nil
@@ -145,9 +144,6 @@ func (p *XPod) doContainerCreate(c *apitypes.UserContainer) (string, error) {
 	}
 
 	p.containers[pc.Id()] = pc
-	p.statusLock.Lock()
-	p.snapContainers[pc.Id()] = pc
-	p.statusLock.Unlock()
 
 	vols := pc.volumes()
 	nvs := make([]string, 0, len(vols))
@@ -374,9 +370,6 @@ func (p *XPod) initResources(spec *apitypes.UserPod, allowCreate bool) error {
 			return err
 		}
 		p.containers[c.Id()] = c
-		p.statusLock.Lock()
-		p.snapContainers[c.Id()] = c
-		p.statusLock.Unlock()
 
 		vols := c.volumes()
 		for _, vol := range vols {


### PR DESCRIPTION
After taking a look at the code, I think the snap xxx is useless.
So I remove snapxxx and add lock to the code that will write p.containers and p.volumes with p.statusLock.Lock().