### PR TITLE
Decommision pod resources synchronously in Remove() method

### DIFF
--- a/daemon/pod/decommission.go
+++ b/daemon/pod/decommission.go
@@ -548,10 +548,10 @@ func (p *XPod) cleanup() {
 	defer p.resourceLock.Unlock()
 
 	p.statusLock.Lock()
-	if p.status == S_POD_STOPPED || p.status == S_POD_NONE {
+	if p.status == S_POD_STOPPED {
 		p.statusLock.Unlock()
 		return
-	} else {
+	} else if p.status != S_POD_NONE {
 		p.status = S_POD_STOPPING
 	}
 	p.statusLock.Unlock()


### PR DESCRIPTION
fixes #733 

This will deallocate everything physically belonging to a pod right after those same things are deleted from the hyper DB.