### PR TITLE
buffer: Handle the control operations (ContainerCreate) asynchronously

### DIFF
--- a/daemon/buffer/buffer.go
+++ b/daemon/buffer/buffer.go
@@ -1,0 +1,98 @@
+package buffer
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/hyperhq/hyperd/daemon/pod"
+	apitypes "github.com/hyperhq/hyperd/types"
+)
+
+type Buffer struct {
+	goroutinesLimit uint64
+	goroutinesLock  sync.Mutex
+	ch              chan *pod.ContainerBuffer
+}
+
+const (
+	DefaultBufferChannelSize = 1024
+)
+
+func NewBuffer(cfg *apitypes.HyperConfig) *Buffer {
+	if cfg.BufferGoroutinesMax == 0 {
+		return nil
+	}
+	if cfg.BufferChannelSize == 0 {
+		cfg.BufferChannelSize = DefaultBufferChannelSize
+	}
+
+	daemon := &Buffer{
+		goroutinesLimit: cfg.BufferGoroutinesMax,
+		ch:              make(chan *pod.ContainerBuffer, cfg.BufferChannelSize),
+	}
+
+	return daemon
+}
+
+func (b *Buffer) CreateContainerInPod(p *pod.XPod, c *apitypes.UserContainer) (string, error) {
+	if !p.IsAlive() {
+		err := fmt.Errorf("pod is not running")
+		p.Log(pod.ERROR, "%v", err)
+		return "", err
+	}
+	if err := p.ReserveContainerName(c); err != nil {
+		return "", err
+	}
+
+	cb, err := p.AddContainerBuffer(c)
+	if err != nil {
+		return "", err
+	}
+
+	b.goroutinesLock.Lock()
+	defer b.goroutinesLock.Unlock()
+	if b.goroutinesLimit != 0 {
+		b.goroutinesLimit--
+		go b.containerHandler(cb)
+		glog.V(3).Infof("Put %+v to containerHandler, current limit %v", c, b.goroutinesLimit)
+	} else {
+		select {
+		case b.ch <- cb:
+			glog.V(3).Infof("Put %+v to channel", c)
+		default:
+			err := fmt.Errorf("%+v dropped because channel is full", c)
+			glog.Errorf("%s", err)
+			p.RemoveContainerBufferAll(cb)
+			return "", err
+		}
+	}
+
+	return cb.Id, nil
+}
+
+func (b *Buffer) containerHandler(cb *pod.ContainerBuffer) {
+loop:
+	for {
+		glog.V(3).Infof("Buffer begin to handle %+v", cb)
+		id, err := cb.P.DoContainerCreate(cb.Spec, cb.Id)
+		if err == nil {
+			cb.P.RemoveContainerBuffer(cb)
+			glog.V(3).Infof("Buffer handle %+v done, new id is %s", cb, id)
+		} else {
+			cb.P.RemoveContainerBufferAll(cb)
+			glog.Errorf("Buffer handle %+v failed %v", cb, err)
+		}
+
+		b.goroutinesLock.Lock()
+		select {
+		case cb = <-b.ch:
+			b.goroutinesLock.Unlock()
+		default:
+			defer b.goroutinesLock.Unlock()
+			b.goroutinesLimit++
+			break loop
+		}
+	}
+	glog.V(3).Infof("Channel is empty, current limit %v", b.goroutinesLimit)
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/hyperhq/hyperd/daemon/buffer"
 	"github.com/hyperhq/hyperd/daemon/daemondb"
 	"github.com/hyperhq/hyperd/daemon/pod"
 	"github.com/hyperhq/hyperd/networking/portmapping"
@@ -41,6 +42,8 @@ type Daemon struct {
 	Storage    Storage
 	Hypervisor string
 	DefaultLog *pod.GlobalLogConfig
+
+	buffer *buffer.Buffer
 }
 
 func (daemon *Daemon) Restore() error {
@@ -117,6 +120,7 @@ func NewDaemon(cfg *apitypes.HyperConfig) (*Daemon, error) {
 		db:      db,
 		PodList: pod.NewPodList(),
 		Host:    cfg.Host,
+		buffer:  buffer.NewBuffer(cfg),
 	}
 
 	daemon.Daemon, err = docker.NewDaemon(dockerCfg, registryCfg)

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -55,6 +55,7 @@ func (daemon *Daemon) ListContainers(podId, vmId string) ([]*apitypes.ContainerL
 				result = append(result, status)
 			}
 		}
+		result = p.AppendContainerBufferStatus(result)
 	}
 	return result, nil
 }
@@ -118,6 +119,7 @@ func (daemon *Daemon) List(item, podId, vmId string) (map[string][]string, error
 				if status != "" {
 					containerJsonResponse = append(containerJsonResponse, status)
 				}
+				containerJsonResponse = p.AppendContainerBufferStatusString(containerJsonResponse)
 			}
 		}
 	}

--- a/daemon/pod/buffer.go
+++ b/daemon/pod/buffer.go
@@ -1,0 +1,133 @@
+package pod
+
+import (
+	"github.com/docker/docker/pkg/stringid"
+	apitypes "github.com/hyperhq/hyperd/types"
+	"strings"
+)
+
+type ContainerBuffer struct {
+	Id   string
+	P    *XPod
+	Spec *apitypes.UserContainer
+}
+
+func (cb *ContainerBuffer) info() *apitypes.Container {
+	cinfo := &apitypes.Container{
+		Name:            "/" + cb.Spec.Name,
+		ContainerID:     cb.Id,
+		Image:           cb.Spec.Image,
+		Commands:        cb.Spec.Command,
+		WorkingDir:      cb.Spec.Workdir,
+		Labels:          cb.Spec.Labels,
+		Ports:           make([]*apitypes.ContainerPort, 0, len(cb.Spec.Ports)),
+		VolumeMounts:    make([]*apitypes.VolumeMount, 0, len(cb.Spec.Volumes)),
+		Env:             make([]*apitypes.EnvironmentVar, 0, len(cb.Spec.Envs)),
+		Tty:             cb.Spec.Tty,
+		ImagePullPolicy: "",
+	}
+	for _, port := range cb.Spec.Ports {
+		cinfo.Ports = append(cinfo.Ports, &apitypes.ContainerPort{
+			HostPort:      port.HostPort,
+			ContainerPort: port.ContainerPort,
+			Protocol:      port.Protocol,
+		})
+	}
+	for _, vol := range cb.Spec.Volumes {
+		cinfo.VolumeMounts = append(cinfo.VolumeMounts, &apitypes.VolumeMount{
+			Name:      vol.Volume,
+			MountPath: vol.Path,
+			ReadOnly:  vol.ReadOnly,
+		})
+	}
+	for _, env := range cb.Spec.Envs {
+		cinfo.Env = append(cinfo.Env, &apitypes.EnvironmentVar{
+			Env:   env.Env,
+			Value: env.Value,
+		})
+	}
+	return cinfo
+}
+
+func (cb *ContainerBuffer) infoStatus() *apitypes.ContainerStatus {
+	s := &apitypes.ContainerStatus{
+		Name:        cb.Spec.Name,
+		ContainerID: cb.Id,
+		Waiting:     &apitypes.WaitingStatus{Reason: "Pending"},
+		Running:     &apitypes.RunningStatus{StartedAt: ""},
+		Terminated:  &apitypes.TermStatus{},
+		Phase:       "pending",
+	}
+	return s
+}
+
+func (p *XPod) AddContainerBuffer(c *apitypes.UserContainer) (*ContainerBuffer, error) {
+	cid := stringid.GenerateNonCryptoID()
+
+	cb := &ContainerBuffer{
+		Id:   cid,
+		P:    p,
+		Spec: c,
+	}
+	p.statusLock.Lock()
+	p.containerBuffers[cid] = cb
+	p.statusLock.Unlock()
+
+	err := p.factory.registry.ReserveContainer(cid, c.Name, p.Id())
+	if err != nil {
+		p.RemoveContainerBuffer(cb)
+		return nil, err
+	}
+
+	return cb, nil
+}
+
+func (p *XPod) RemoveContainerBuffer(cb *ContainerBuffer) {
+	p.statusLock.Lock()
+	defer p.statusLock.Unlock()
+	delete(p.containerBuffers, cb.Id)
+}
+
+func (p *XPod) RemoveContainerBufferAll(cb *ContainerBuffer) {
+	p.factory.registry.ReleaseContainer(cb.Id, cb.Spec.Name)
+
+	p.RemoveContainerBuffer(cb)
+}
+
+func (p *XPod) AppendContainerBufferStatus(result []*apitypes.ContainerListResult) []*apitypes.ContainerListResult {
+	p.statusLock.RLock()
+	defer p.statusLock.RUnlock()
+	for id, cb := range p.containerBuffers {
+		result = append(result, &apitypes.ContainerListResult{
+			ContainerID:   id,
+			ContainerName: cb.Spec.Name,
+			PodID:         p.Id(),
+			Status:        "pending",
+		})
+	}
+	return result
+}
+
+func (p *XPod) AppendContainerBufferStatusString(result []string) []string {
+	p.statusLock.RLock()
+	defer p.statusLock.RUnlock()
+	for id, cb := range p.containerBuffers {
+		result = append(result, strings.Join([]string{id, cb.Spec.Name, p.Id(), "pending"}, ":"))
+	}
+	return result
+}
+
+func (p *XPod) ContainerBufferInfo(cid string) *apitypes.ContainerInfo {
+	p.statusLock.RLock()
+	defer p.statusLock.RUnlock()
+	if cb, ok := p.containerBuffers[cid]; ok {
+		//Not set CreatedAt
+		ci := &apitypes.ContainerInfo{
+			PodID:     p.Id(),
+			Container: cb.info(),
+			Status:    cb.infoStatus(),
+		}
+		return ci
+	}
+	return nil
+}

--- a/daemon/pod/podlist.go
+++ b/daemon/pod/podlist.go
@@ -71,6 +71,20 @@ func (pl *PodList) ReserveContainer(id, name, pod string) error {
 	return nil
 }
 
+func (pl *PodList) ChangeContainerId(oldId, newId, pod string) error {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	if _, ok := pl.pods[pod]; !ok {
+		return fmt.Errorf("pod %s not exist for Changing container %s", pod, oldId)
+	}
+	if pn, ok := pl.containers[newId]; ok && pn != pod {
+		return fmt.Errorf("the container id %s has already taken by pod %s", newId, pn)
+	}
+	delete(pl.containers, oldId)
+	pl.containers[newId] = pod
+	return nil
+}
+
 func (pl *PodList) ReservePod(p *XPod) error {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -77,6 +77,10 @@ func (daemon *Daemon) CreateContainerInPod(podId string, spec *apitypes.UserCont
 		return "", fmt.Errorf("The pod(%s) can not be found", podId)
 	}
 
+	if daemon.buffer != nil {
+		return daemon.buffer.CreateContainerInPod(p, spec)
+	}
+
 	return p.ContainerCreate(spec)
 }
 

--- a/types/config.go
+++ b/types/config.go
@@ -32,6 +32,9 @@ type HyperConfig struct {
 	GDBTCPPort      int
 
 	logPrefix string
+
+	BufferGoroutinesMax uint64
+	BufferChannelSize   uint64
 }
 
 func NewHyperConfig(config string) *HyperConfig {
@@ -77,6 +80,25 @@ func NewHyperConfig(config string) *HyperConfig {
 		c.GDBTCPPort, err = strconv.Atoi(port)
 		if err != nil {
 			c.Log(hlog.ERROR, "read config file GDBTCPPort %s failed: %v", port, err)
+			return nil
+		}
+	}
+
+	max, _ := cfg.GetValue(goconfig.DEFAULT_SECTION, "BufferGoroutinesMax")
+	if max != "" {
+		var err error
+		c.BufferGoroutinesMax, err = strconv.ParseUint(max, 0, 64)
+		if err != nil {
+			c.Log(hlog.ERROR, "read config file BufferGoroutinesMax failed: %v", err)
+			return nil
+		}
+	}
+	size, _ := cfg.GetValue(goconfig.DEFAULT_SECTION, "BufferChannelSize")
+	if size != "" {
+		var err error
+		c.BufferChannelSize, err = strconv.ParseUint(size, 0, 64)
+		if err != nil {
+			c.Log(hlog.ERROR, "read config file BufferChannelSize failed: %v", err)
 			return nil
 		}
 	}


### PR DESCRIPTION
Currently, hyperd handles all the control operations synchronously.
K8S will wait the result long time if there are a lot of operations
in same time.

This patch put control operations (just support ContainerCreate now)
to buffer and put back the result at once.
The buffer will handle the result in goroutins pool (the size can be
config by BufferGoroutinesMax and BufferChannelSize).

When open buffer function, hyperd can pass most of test in hyper_test.go
but not TestRenameContainer and TestSendContainerSignal.
Because after container created, the id of container will be changed to
the id that get from docker.

Signed-off-by: Hui Zhu <teawater@hyper.sh>